### PR TITLE
fix(aladinBookDTO) insertAladinBook 정보 추가, fullDescription2 추가

### DIFF
--- a/src/main/java/com/undefinedus/backend/dto/request/book/AladinBookRequestDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/request/book/AladinBookRequestDTO.java
@@ -19,6 +19,8 @@ public class AladinBookRequestDTO {
 
     private String fullDescription;   // 도서 소개
 
+    private String fullDescription2;   // 도서 소개 정보량 많음 // gpt에게 토론용 책에 대한 정보를 주기 위해 필요
+
     private String publisher;     // 출판사
 
     private String categoryName;  // 카테고리명

--- a/src/main/java/com/undefinedus/backend/service/AladinBookServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/AladinBookServiceImpl.java
@@ -60,6 +60,7 @@ public class AladinBookServiceImpl implements AladinBookService {
             .link(requestDTO.getLink())
             .cover(requestDTO.getCover())
             .fullDescription(requestDTO.getFullDescription())
+            .fullDescription2(requestDTO.getFullDescription2())
             .publisher(requestDTO.getPublisher())
             .categoryName(requestDTO.getCategoryName())
             .customerReviewRank(requestDTO.getCustomerReviewRank())


### PR DESCRIPTION
- AladinBookRequestDTO에 fullDescription2 추가 gpt에 정보를 전달하기 위한 fullDescription2 추가
- aladinBook에 fullDescription2 정보 저장 aladinBook의 정보를 gpt에게 넘기기 때문에 aladinBook을 저장할 때 fullDescription2이것도 저장해야 함.