### PR TITLE
fix(Statistics): 카테고리 별 통계 수정

### DIFF
--- a/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
@@ -74,7 +74,7 @@ public class DiscussionServiceImpl implements DiscussionService {
 
         // 상태 변경 작업 스케줄링
         try {
-            quartzConfig.scheduleJobs(savedDiscussion.getStartDate(), savedDiscussion.getId());
+            quartzConfig.scheduleDiscussionJobs(savedDiscussion.getStartDate(), savedDiscussion.getId());
         } catch (SchedulerException e) {
             log.error(
                 "Failed to schedule status change jobs for discussion: " + savedDiscussion.getId(),
@@ -236,7 +236,7 @@ public class DiscussionServiceImpl implements DiscussionService {
 
         Discussion save = discussionRepository.save(discussion);
 
-        quartzConfig.scheduleJobs(save.getStartDate(), save.getId());
+        quartzConfig.scheduleDiscussionJobs(save.getStartDate(), save.getId());
 
         return save.getId();
     }

--- a/src/test/java/com/undefinedus/backend/service/DiscussionServiceImplTest.java
+++ b/src/test/java/com/undefinedus/backend/service/DiscussionServiceImplTest.java
@@ -111,7 +111,7 @@ class DiscussionServiceImplTest {
         when(discussionRepository.save(any(Discussion.class))).thenReturn(discussion);
 
         // Quartz Config Mock
-        doNothing().when(quartzConfig).scheduleJobs(any(LocalDateTime.class), anyLong());
+        doNothing().when(quartzConfig).scheduleDiscussionJobs(any(LocalDateTime.class), anyLong());
 
         // 메서드 호출
         Long discussionId = discussionServiceImpl.discussionRegister(memberId, isbn13,
@@ -122,7 +122,7 @@ class DiscussionServiceImplTest {
         assertEquals(1L, discussionId);  // 반환된 토론 ID가 1L인지 확인
 
         // quartzConfig.scheduleJobs 호출 여부 검증
-        verify(quartzConfig, times(1)).scheduleJobs(any(LocalDateTime.class), anyLong());
+        verify(quartzConfig, times(1)).scheduleDiscussionJobs(any(LocalDateTime.class), anyLong());
 
         // discussionRepository.save 호출 여부 검증
         verify(discussionRepository, times(1)).save(any(Discussion.class));
@@ -254,7 +254,7 @@ class DiscussionServiceImplTest {
         when(myBookRepository.findByMemberIdAndIsbn13(memberId, isbn13)).thenReturn(java.util.Optional.of(mockMyBook));
         when(discussionRepository.findById(discussionId)).thenReturn(java.util.Optional.of(mockDiscussion));
         when(discussionRepository.save(any(Discussion.class))).thenReturn(mockDiscussion);
-        doNothing().when(quartzConfig).scheduleJobs(any(LocalDateTime.class), anyLong());
+        doNothing().when(quartzConfig).scheduleDiscussionJobs(any(LocalDateTime.class), anyLong());
 
         // 메서드 호출
         Long modifiedDiscussionId = discussionServiceImpl.discussionUpdate(memberId, isbn13, discussionId, requestDTO);
@@ -265,7 +265,7 @@ class DiscussionServiceImplTest {
 
         // Mock 객체 호출 여부 검증
         verify(discussionRepository, times(1)).save(any(Discussion.class));
-        verify(quartzConfig, times(1)).scheduleJobs(any(LocalDateTime.class), anyLong());
+        verify(quartzConfig, times(1)).scheduleDiscussionJobs(any(LocalDateTime.class), anyLong());
 
         // 업데이트된 값 검증
         assertEquals("Updated Title", mockDiscussion.getTitle());


### PR DESCRIPTION
- 카테고리 별 통계 수정 카테고리의 풀 네임이 다르면 통계에 쓰는 카테고리의 이름이 같아도 다른 카테고리로 보기 때문에 카운트를 따로한다. 그래서 카테고리 이름이 같으면 하나의 카테고리로 보고 카운트 하는 코드 작성