### PR TITLE
fix(discussion, comment, report): 토론 출력 되는 내용, 신고 하기 내용, 댓글 달기 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,8 @@ dependencies {
     testImplementation 'com.github.database-rider:rider-junit5:1.32.0'
 
     // 욕 필터링 라이브러리
-    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'}
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
+}
 
 // chat gpt
 dependencyManagement {

--- a/src/main/java/com/undefinedus/backend/config/InitialDataConfig.java
+++ b/src/main/java/com/undefinedus/backend/config/InitialDataConfig.java
@@ -818,7 +818,7 @@ public class InitialDataConfig {
                 .content(content)
                 .parentId(parentId)
                 .groupId(groupId)
-                .order(order)
+                .groupOrder(order)
                 .isChild(isChild)
                 .totalOrder(totalOrder)
                 .build();

--- a/src/main/java/com/undefinedus/backend/controller/AiController.java
+++ b/src/main/java/com/undefinedus/backend/controller/AiController.java
@@ -23,7 +23,7 @@ public class AiController {
 
     // 회원이 읽은 책들 기반 gpt 추천 도서 목록(gpt가 추천 책의 isbn13을 출력하지 않음)
     @GetMapping("/recommended")
-    public ResponseEntity<ApiResponseDTO<List<AladinApiResponseDTO>>> getGPTRecommendedBookLIst(
+    public ResponseEntity<ApiResponseDTO<List<AladinApiResponseDTO>>> getPerplexityRecommendedBookList(
         @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO) {
 
         Long memberId = memberSecurityDTO.getId();

--- a/src/main/java/com/undefinedus/backend/controller/DiscussionCommentController.java
+++ b/src/main/java/com/undefinedus/backend/controller/DiscussionCommentController.java
@@ -74,6 +74,7 @@ public class DiscussionCommentController {
         return ResponseEntity.ok(ApiResponseDTO.success(best3CommentByCommentLikes));
     }
 
+    // 댓글 리스트
     @GetMapping
     public ResponseEntity<ApiResponseDTO<ScrollResponseDTO<DiscussionCommentResponseDTO>>> getCommentList(
         @ModelAttribute DiscussionCommentsScrollRequestDTO requestDTO

--- a/src/main/java/com/undefinedus/backend/controller/DiscussionController.java
+++ b/src/main/java/com/undefinedus/backend/controller/DiscussionController.java
@@ -76,7 +76,7 @@ public class DiscussionController {
     }
 
     // 발의글에 찬성으로 참여하기
-    @GetMapping("/joinAgree")
+    @PostMapping("/joinAgree")
     public ResponseEntity<ApiResponseDTO<Void>> joinAgree(
         @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO,
         @RequestParam("discussionId") Long discussionId
@@ -95,7 +95,7 @@ public class DiscussionController {
     }
 
     // 발의글에 반대로 참석하기
-    @GetMapping("/joinDisagree")
+    @PostMapping("/joinDisagree")
     public ResponseEntity<ApiResponseDTO<Void>> joinDisagree(
         @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO,
         @RequestParam("discussionId") Long discussionId

--- a/src/main/java/com/undefinedus/backend/controller/ReportController.java
+++ b/src/main/java/com/undefinedus/backend/controller/ReportController.java
@@ -27,15 +27,31 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    @PostMapping("/reportDiscussionAndComment")
-    public ResponseEntity<ApiResponseDTO<Void>> report(
+    @PostMapping("/discussion/{discussionId}")
+    public ResponseEntity<ApiResponseDTO<Void>> reportDiscussion(
         @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO,
+        @PathVariable("discussionId") Long discussionId,
         @RequestBody ReportRequestDTO reportRequestDTO
     ) {
 
         Long memberId = memberSecurityDTO.getId();
 
-        reportService.report(memberId, reportRequestDTO);
+        reportService.reportDiscussion(memberId, discussionId, reportRequestDTO);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ApiResponseDTO.success(null));
+    }
+
+    @PostMapping("/comment/{commentId}")
+    public ResponseEntity<ApiResponseDTO<Void>> reportComment(
+        @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO,
+        @PathVariable("commentId") Long commentId,
+        @RequestBody ReportRequestDTO reportRequestDTO
+    ) {
+
+        Long memberId = memberSecurityDTO.getId();
+
+        reportService.reportComment(memberId, commentId, reportRequestDTO);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponseDTO.success(null));

--- a/src/main/java/com/undefinedus/backend/domain/entity/DiscussionComment.java
+++ b/src/main/java/com/undefinedus/backend/domain/entity/DiscussionComment.java
@@ -56,8 +56,8 @@ public class DiscussionComment extends BaseEntity {
     @Column
     private Long parentId; // 부모Id // 고유 아이디는 id로 사용
     
-    @Column(name = "comment_order")  // 'order' 대신 'comment_order' 사용
-    private Long order;
+    @Column
+    private Long groupOrder;
 
     @Column
     @Builder.Default

--- a/src/main/java/com/undefinedus/backend/domain/entity/Member.java
+++ b/src/main/java/com/undefinedus/backend/domain/entity/Member.java
@@ -171,7 +171,7 @@ public class Member extends BaseEntity {
         this.kakaoAccessToken = kakaoAccessToken;
     }
 
-    public void updateMessageToKakao(boolean messageToKakao) {
+    public void updateIsMessageToKakao(boolean messageToKakao) {
         isMessageToKakao = messageToKakao;
     }
 

--- a/src/main/java/com/undefinedus/backend/dto/request/discussion/DiscussionRegisterRequestDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/request/discussion/DiscussionRegisterRequestDTO.java
@@ -9,9 +9,9 @@ import lombok.Data;
 @Builder
 public class DiscussionRegisterRequestDTO {
 
-    private Long myBook;  // 어떤 책의 토론인지 // 내가 기록한 책만 토론 주제로 올릴 수 있음
+    private Long myBookId;  // 어떤 책의 토론인지 // 내가 기록한 책만 토론 주제로 올릴 수 있음
 
-    private Long member;  // 작성자
+    private Long memberId;  // 작성자
 
     @NoProfanity
     private String title;    // 토론 제목

--- a/src/main/java/com/undefinedus/backend/dto/request/report/ReportRequestDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/request/report/ReportRequestDTO.java
@@ -12,13 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReportRequestDTO {
 
-    private Long reportedId;  // 신고 당한 사람 // 댓글, 게시물 만든 유저
+    private String reason;  // 신고 이유
 
-    private String targetType;  // 신고 대상 타입 (Discussion, Comment 등)
-
-    private String reason;  // 신고 대상 타입 (Discussion, Comment 등)
-
-    private Long discussionId;  // 신고 당한 토론 게시물 // comment가 존재하면 null
-
-    private Long commentId;  // 신고 당한 토론 댓글 게시물 // discussion가 존재하면 null
 }

--- a/src/main/java/com/undefinedus/backend/dto/response/discussion/DiscussionDetailResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/discussion/DiscussionDetailResponseDTO.java
@@ -8,6 +8,9 @@ import lombok.Data;
 @Builder
 public class DiscussionDetailResponseDTO {
 
+
+    private Long discussionId;  // 신고 용
+
     private String bookTitle;  // 어떤 책의 토론인지
 
     private String memberName;  // 작성자

--- a/src/main/java/com/undefinedus/backend/dto/response/discussionComment/DiscussionCommentResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/discussionComment/DiscussionCommentResponseDTO.java
@@ -20,6 +20,8 @@ public class DiscussionCommentResponseDTO {
 
     private Long parentId; // 부모Id // 고유 아이디는 id로 사용
 
+    private Long groupId;
+
     private Long order;
 
     private Long totalOrder;

--- a/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
@@ -194,6 +194,7 @@ public class DiscussionServiceImpl implements DiscussionService {
         Discussion savedDiscussion = discussionRepository.save(discussion);
 
         DiscussionDetailResponseDTO discussionDetailResponseDTO = DiscussionDetailResponseDTO.builder()
+            .discussionId(discussionId)
             .bookTitle(discussionBook.getTitle())
             .memberName(discussion.getMember().getNickname())
             .title(savedDiscussion.getTitle())
@@ -260,25 +261,28 @@ public class DiscussionServiceImpl implements DiscussionService {
         DiscussionParticipant savedParticipant = discussionParticipantRepository.findByDiscussionAndMember(
             discussion, member).orElse(null);
 
-        if (savedParticipant == null) {
-            DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
-                .discussion(discussion)
-                .member(member)
-                .isAgree(true)
-                .build();
+        if (discussion.getStatus() == DiscussionStatus.PROPOSED) {
 
-            discussionParticipantRepository.save(discussionParticipant);
-        } else {
-            if (!savedParticipant.isAgree()) {
-
-                discussionParticipantRepository.deleteById(savedParticipant.getId());
-
+            if (savedParticipant == null) {
                 DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
                     .discussion(discussion)
                     .member(member)
                     .isAgree(true)
                     .build();
+
                 discussionParticipantRepository.save(discussionParticipant);
+            } else {
+                if (!savedParticipant.isAgree()) {
+
+                    discussionParticipantRepository.deleteById(savedParticipant.getId());
+
+                    DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
+                        .discussion(discussion)
+                        .member(member)
+                        .isAgree(true)
+                        .build();
+                    discussionParticipantRepository.save(discussionParticipant);
+                }
             }
         }
     }
@@ -296,19 +300,8 @@ public class DiscussionServiceImpl implements DiscussionService {
         DiscussionParticipant savedParticipant = discussionParticipantRepository.findByDiscussionAndMember(
             discussion, member).orElse(null);
 
-        if (savedParticipant == null) {
-            DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
-                .discussion(discussion)
-                .member(member)
-                .isAgree(false)
-                .build();
-
-            discussionParticipantRepository.save(discussionParticipant);
-        } else {
-            if (savedParticipant.isAgree()) {
-
-                discussionParticipantRepository.deleteById(savedParticipant.getId());
-
+        if (discussion.getStatus() == DiscussionStatus.PROPOSED) {
+            if (savedParticipant == null) {
                 DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
                     .discussion(discussion)
                     .member(member)
@@ -316,6 +309,19 @@ public class DiscussionServiceImpl implements DiscussionService {
                     .build();
 
                 discussionParticipantRepository.save(discussionParticipant);
+            } else {
+                if (savedParticipant.isAgree()) {
+
+                    discussionParticipantRepository.deleteById(savedParticipant.getId());
+
+                    DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
+                        .discussion(discussion)
+                        .member(member)
+                        .isAgree(false)
+                        .build();
+
+                    discussionParticipantRepository.save(discussionParticipant);
+                }
             }
         }
     }

--- a/src/main/java/com/undefinedus/backend/service/MyPageServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/MyPageServiceImpl.java
@@ -26,6 +26,7 @@ public class MyPageServiceImpl implements MyPageService {
     private final MemberRepository memberRepository;
 
     // 카카오 회원이 카카오톡 메시지 권한을 허용했는지 체크
+    @Override
     public Boolean checkMessagePermission(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + memberId));
@@ -54,7 +55,7 @@ public class MyPageServiceImpl implements MyPageService {
                 }
 
                 member.updateKakaoMessageIsAgree(isMessageToKakao);
-                member.updateMessageToKakao(isMessageToKakao);
+                member.updateIsMessageToKakao(isMessageToKakao);
             }
             return isMessageToKakao;
         } else {
@@ -63,6 +64,7 @@ public class MyPageServiceImpl implements MyPageService {
     }
 
     // 카카오톡 메시지를 받을지 회원이 체크하는 메서드
+    @Override
     public boolean updateMessageToKakao(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + memberId));
@@ -71,73 +73,76 @@ public class MyPageServiceImpl implements MyPageService {
 
         if (KakaoMessageIsAgree != null) {
 
-            member.updateMessageToKakao(!KakaoMessageIsAgree);
-            removeMessagePermission(memberId);
+            member.updateIsMessageToKakao(!KakaoMessageIsAgree);
+//            if (!member.isMessageToKakao()) {
+//
+//                removeMessagePermission(memberId);
+//            }
         }
 
         return member.isMessageToKakao();
     }
 
     // 카카오톡 권한 철회
-    private void removeMessagePermission(Long memberId) {
+//    private void removeMessagePermission(Long memberId) {
+//
+//        Member member = memberRepository.findById(memberId)
+//            .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + memberId));
+//
+//        String kakaoAccessToken = member.getKakaoAccessToken();
+//
+//        // getRevocableScopes 메서드를 사용하여 철회 가능한 권한 목록을 가져옴
+//        List<String> revocableScopes = getRevocableScopes(memberId);
+//
+//        // 철회할 권한이 없으면 종료
+//        if (revocableScopes.isEmpty()) {
+//            System.out.println("철회할 권한이 없습니다.");
+//            return;
+//        }
+//
+//        String url = "https://kapi.kakao.com/v2/user/revoke/scopes";
+//
+//        // 헤더 설정
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.add("Authorization", "Bearer " + kakaoAccessToken);
+//        headers.setContentType(MediaType.APPLICATION_JSON);
+//
+//        // 바디 설정
+//        Map<String, Object> body = new HashMap<>();
+//        body.put("scopes", revocableScopes);
+//
+//        // 요청 엔티티 생성
+//        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+//
+//        // RestTemplate 호출
+//        RestTemplate restTemplate = new RestTemplate();
+//        ResponseEntity<String> response = restTemplate.exchange(
+//            url,
+//            HttpMethod.POST,
+//            requestEntity,
+//            String.class
+//        );
+//
+//        // 응답 처리
+//        System.out.println("Response: " + response.getBody());
+//
+//    }
 
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + memberId));
-
-        String kakaoAccessToken = member.getKakaoAccessToken();
-
-        // getRevocableScopes 메서드를 사용하여 철회 가능한 권한 목록을 가져옴
-        List<String> revocableScopes = getRevocableScopes(memberId);
-
-        // 철회할 권한이 없으면 종료
-        if (revocableScopes.isEmpty()) {
-            System.out.println("철회할 권한이 없습니다.");
-            return;
-        }
-
-        String url = "https://kapi.kakao.com/v2/user/revoke/scopes";
-
-        // 헤더 설정
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + kakaoAccessToken);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        // 바디 설정
-        Map<String, Object> body = new HashMap<>();
-        body.put("scopes", revocableScopes);
-
-        // 요청 엔티티 생성
-        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-        // RestTemplate 호출
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> response = restTemplate.exchange(
-            url,
-            HttpMethod.POST,
-            requestEntity,
-            String.class
-        );
-
-        // 응답 처리
-        System.out.println("Response: " + response.getBody());
-
-    }
-
-    public List<String> getRevocableScopes(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + memberId));
-
-        String accessToken = member.getKakaoAccessToken(); // 저장된 Kakao Access Token
-
-        Map<String, Object> scopesResponse = getKakaoScopes(accessToken);
-        List<Map<String, Object>> scopes = (List<Map<String, Object>>) scopesResponse.get("scopes");
-
-        // revocable이 true인 항목의 id를 리스트로 수집
-        return scopes.stream()
-            .filter(scope -> (Boolean) scope.get("revocable")) // 철회 가능한 항목만 필터링
-            .map(scope -> (String) scope.get("id")) // id 값 추출
-            .toList(); // 리스트로 변환
-    }
+//    public List<String> getRevocableScopes(Long memberId) {
+//        Member member = memberRepository.findById(memberId)
+//            .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + memberId));
+//
+//        String accessToken = member.getKakaoAccessToken(); // 저장된 Kakao Access Token
+//
+//        Map<String, Object> scopesResponse = getKakaoScopes(accessToken);
+//        List<Map<String, Object>> scopes = (List<Map<String, Object>>) scopesResponse.get("scopes");
+//
+//        // revocable이 true인 항목의 id를 리스트로 수집
+//        return scopes.stream()
+//            .filter(scope -> (Boolean) scope.get("revocable")) // 철회 가능한 항목만 필터링
+//            .map(scope -> (String) scope.get("id")) // id 값 추출
+//            .toList(); // 리스트로 변환
+//    }
 
     // 카카오 API 호출 로직을 별도로 분리
     private Map<String, Object> getKakaoScopes(String accessToken) {

--- a/src/main/java/com/undefinedus/backend/service/ReportService.java
+++ b/src/main/java/com/undefinedus/backend/service/ReportService.java
@@ -7,8 +7,11 @@ import com.undefinedus.backend.dto.response.report.ReportResponseDTO;
 
 public interface ReportService {
 
-    void report(Long reporterId, ReportRequestDTO reportRequestDTO);
-    
+    void reportDiscussion(Long reporterId, Long discussionId,
+        ReportRequestDTO reportRequestDTO);
+
+    void reportComment(Long reporterId, Long commentId, ReportRequestDTO reportRequestDTO);
+
     ScrollResponseDTO<ReportResponseDTO> getReportList(ScrollRequestDTO requestDTO);
     
     ReportResponseDTO getReportDetail(Long reportId);

--- a/src/test/java/com/undefinedus/backend/repository/DiscussionCommentRepositoryTest.java
+++ b/src/test/java/com/undefinedus/backend/repository/DiscussionCommentRepositoryTest.java
@@ -8,10 +8,7 @@ import com.undefinedus.backend.domain.entity.MyBook;
 import com.undefinedus.backend.domain.enums.BookStatus;
 import com.undefinedus.backend.domain.enums.DiscussionStatus;
 import com.undefinedus.backend.domain.enums.VoteType;
-import com.undefinedus.backend.dto.response.discussionComment.DiscussionCommentResponseDTO;
 import jakarta.persistence.EntityManager;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -186,47 +183,6 @@ class DiscussionCommentRepositoryTest {
     @DisplayName("연결 확인")
     void testConnection() {
         assertNotNull(discussionCommentRepository);
-    }
-
-    @Test
-    @DisplayName("findTopOrder 메서드 테스트")
-    void testFindTopOrder() {
-        // 댓글을 두 개 추가
-        DiscussionComment parentComment = DiscussionComment.builder()
-            .discussion(discussion)
-            .member(member1)
-            .parentId(null)
-            .order(1L)
-            .voteType(VoteType.AGREE)
-            .content("Parent Comment")
-            .build();
-        discussionCommentRepository.save(parentComment);
-
-        DiscussionComment childComment1 = DiscussionComment.builder()
-            .discussion(discussion)
-            .member(member2)
-            .parentId(parentComment.getId())
-            .order(1L)
-            .voteType(VoteType.DISAGREE)
-            .content("Child Comment 1")
-            .build();
-        discussionCommentRepository.save(childComment1);
-
-        DiscussionComment childComment2 = DiscussionComment.builder()
-            .discussion(discussion)
-            .member(member3)
-            .parentId(parentComment.getId())
-            .order(2L)
-            .voteType(VoteType.DISAGREE)
-            .content("Child Comment 2")
-            .build();
-        discussionCommentRepository.save(childComment2);
-
-        // 메소드 실행
-        Long topOrder = discussionCommentRepository.findTopOrder(discussion.getId(), parentComment.getId()).orElse(0L) + 1;
-
-        // 검증
-        assertThat(topOrder).isEqualTo(3L); // 가장 최근의 자식 댓글 order 값이 3이어야 함
     }
 
     @Test

--- a/src/test/java/com/undefinedus/backend/repository/ReportRepositoryTest.java
+++ b/src/test/java/com/undefinedus/backend/repository/ReportRepositoryTest.java
@@ -16,7 +16,6 @@ import com.undefinedus.backend.domain.enums.ReportStatus;
 import com.undefinedus.backend.domain.enums.ReportTargetType;
 import com.undefinedus.backend.domain.enums.VoteType;
 import com.undefinedus.backend.dto.request.ScrollRequestDTO;
-import com.undefinedus.backend.exception.social.TabConditionNotEqualException;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.log4j.Log4j2;
-import org.assertj.core.api.Assertions;
 import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -164,7 +162,7 @@ class ReportRepositoryTest {
             .member(reported)
             .groupId(1L)
             .parentId(0L)
-            .order(1L)
+            .groupOrder(1L)
             .isChild(false)
             .totalOrder(1L)
             .voteType(VoteType.AGREE)
@@ -182,7 +180,7 @@ class ReportRepositoryTest {
             .member(reported)
             .groupId(1L)
             .parentId(0L)
-            .order(2L)
+            .groupOrder(2L)
             .isChild(false)
             .totalOrder(2L)
             .voteType(VoteType.DISAGREE)
@@ -200,7 +198,7 @@ class ReportRepositoryTest {
             .member(reporter)
             .groupId(2L)
             .parentId(1L)
-            .order(1L)
+            .groupOrder(1L)
             .isChild(true)
             .totalOrder(3L)
             .voteType(VoteType.AGREE)
@@ -408,7 +406,7 @@ class ReportRepositoryTest {
                 .member(reported)
                 .groupId(2L)
                 .parentId(0L)
-                .order(1L)
+                .groupOrder(1L)
                 .isChild(false)
                 .totalOrder(1L)
                 .voteType(VoteType.AGREE)

--- a/src/test/java/com/undefinedus/backend/service/ReportServiceImplTest.java
+++ b/src/test/java/com/undefinedus/backend/service/ReportServiceImplTest.java
@@ -29,9 +29,7 @@ import com.undefinedus.backend.repository.ReportRepository;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,30 +40,31 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 class ReportServiceImplTest {
+
     @Autowired
     private ReportServiceImpl reportService;
-    
+
     @Autowired
     private MemberRepository memberRepository;
-    
+
     @Autowired
     private DiscussionRepository discussionRepository;
-    
+
     @Autowired
     private DiscussionCommentRepository discussionCommentRepository;
-    
+
     @Autowired
     private ReportRepository reportRepository;
-    
+
     @Autowired
     private EntityManager entityManager;
-    
+
     @Autowired
     private AladinBookRepository aladinBookRepository;
-    
+
     @Autowired
     private MyBookRepository myBookRepository;
-    
+
     private Member reporter;
     private Member reporter2;
     private Member reported;
@@ -73,340 +72,347 @@ class ReportServiceImplTest {
     private Discussion discussion;
     private MyBook myBook;
     private AladinBook aladinBook;
-    private DiscussionComment comment1;
+    private DiscussionComment comment;
     private DiscussionComment comment2;
     private DiscussionComment comment3;
-    
+    private Report report;
+    private Report report2;
+
+
     @BeforeEach
     void setUp() {
         // Member 데이터 생성
         reporter = Member.builder()
-                .username("test1@example.com")  // 아이디
-                .password("hashedPassword123")  // 암호화된 비밀번호
-                .nickname("테스트닉네임1")  // 닉네임 (2~10자)
-                .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
-                .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
-                .birth(LocalDate.of(1990, 1, 1))  // 생일
-                .gender("남성")  // 성별
-                .isPublic(true)  // 공개 여부
-                .isMessageToKakao(false)  // 카톡 알림 여부
-                .honorific("초보리더")  // 칭호
-                .build();
-        
+            .username("test51@example.com")  // 아이디
+            .password("hashedPassword123")  // 암호화된 비밀번호
+            .nickname("테스트닉네임1")  // 닉네임 (2~10자)
+            .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
+            .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
+            .birth(LocalDate.of(1990, 1, 1))  // 생일
+            .gender("남성")  // 성별
+            .isPublic(true)  // 공개 여부
+            .isMessageToKakao(false)  // 카톡 알림 여부
+            .honorific("초보리더")  // 칭호
+            .build();
+
         reporter2 = Member.builder()
-                .username("test2@example.com")  // 아이디
-                .password("hashedPassword123")  // 암호화된 비밀번호
-                .nickname("테스트닉네임2")  // 닉네임 (2~10자)
-                .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
-                .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
-                .birth(LocalDate.of(1990, 1, 1))  // 생일
-                .gender("남성")  // 성별
-                .isPublic(true)  // 공개 여부
-                .isMessageToKakao(false)  // 카톡 알림 여부
-                .honorific("초보리더")  // 칭호
-                .build();
-        
+            .username("test52@example.com")  // 아이디
+            .password("hashedPassword123")  // 암호화된 비밀번호
+            .nickname("테스트닉네임2")  // 닉네임 (2~10자)
+            .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
+            .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
+            .birth(LocalDate.of(1990, 1, 1))  // 생일
+            .gender("남성")  // 성별
+            .isPublic(true)  // 공개 여부
+            .isMessageToKakao(false)  // 카톡 알림 여부
+            .honorific("초보리더")  // 칭호
+            .build();
+
         reported = Member.builder()
-                .username("test3@example.com")  // 아이디
-                .password("hashedPassword123")  // 암호화된 비밀번호
-                .nickname("테스트닉네임3")  // 닉네임 (2~10자)
-                .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
-                .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
-                .birth(LocalDate.of(1990, 1, 1))  // 생일
-                .gender("여성")  // 성별
-                .isPublic(true)  // 공개 여부
-                .isMessageToKakao(false)  // 카톡 알림 여부
-                .honorific("초보리더")  // 칭호
-                .build();
-        
+            .username("test53@example.com")  // 아이디
+            .password("hashedPassword123")  // 암호화된 비밀번호
+            .nickname("테스트닉네임3")  // 닉네임 (2~10자)
+            .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
+            .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
+            .birth(LocalDate.of(1990, 1, 1))  // 생일
+            .gender("여성")  // 성별
+            .isPublic(true)  // 공개 여부
+            .isMessageToKakao(false)  // 카톡 알림 여부
+            .honorific("초보리더")  // 칭호
+            .build();
+
         reported2 = Member.builder()
-                .username("test4@example.com")  // 아이디
-                .password("hashedPassword123")  // 암호화된 비밀번호
-                .nickname("테스트닉네임4")  // 닉네임 (2~10자)
-                .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
-                .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
-                .birth(LocalDate.of(1990, 1, 1))  // 생일
-                .gender("여성")  // 성별
-                .isPublic(true)  // 공개 여부
-                .isMessageToKakao(false)  // 카톡 알림 여부
-                .honorific("초보리더")  // 칭호
-                .build();
-        
+            .username("test54@example.com")  // 아이디
+            .password("hashedPassword123")  // 암호화된 비밀번호
+            .nickname("테스트닉네임4")  // 닉네임 (2~10자)
+            .profileImage("https://example.com/profile.jpg")  // 프로필 이미지 URL
+            .introduction("안녕하세요! 저는 책을 좋아하는 회원입니다.")  // 자기소개
+            .birth(LocalDate.of(1990, 1, 1))  // 생일
+            .gender("여성")  // 성별
+            .isPublic(true)  // 공개 여부
+            .isMessageToKakao(false)  // 카톡 알림 여부
+            .honorific("초보리더")  // 칭호
+            .build();
+
         memberRepository.save(reporter);
         memberRepository.save(reporter2);
         memberRepository.save(reported);
         memberRepository.save(reported2);
-        
+
         // AladinBook 데이터 생성
         aladinBook = AladinBook.builder()
-                .isbn13("9781234567890")
-                .title("Sample Book")
-                .author("Author Name")
-                .link("https://www.aladin.com/book/1234567890")
-                .cover("https://www.aladin.com/book/cover.jpg")
-                .fullDescription("This is a sample book description.")
-                .fullDescription2("Publisher's description here.")
-                .publisher("Sample Publisher")
-                .categoryName("Fiction")
-                .customerReviewRank(4.5)
-                .itemPage(300)
-                .build();
+            .isbn13("9781234567890")
+            .title("Sample Book")
+            .author("Author Name")
+            .link("https://www.aladin.com/book/1234567890")
+            .cover("https://www.aladin.com/book/cover.jpg")
+            .fullDescription("This is a sample book description.")
+            .fullDescription2("Publisher's description here.")
+            .publisher("Sample Publisher")
+            .categoryName("Fiction")
+            .customerReviewRank(4.5)
+            .itemPage(300)
+            .build();
         aladinBookRepository.save(aladinBook);
-        
+
         // MyBook 데이터 생성
         myBook = MyBook.builder()
-                .member(reported)
-                .aladinBook(aladinBook)
-                .isbn13("9781234567890")
-                .status(BookStatus.READING)
-                .myRating(4.0)
-                .oneLineReview("Great book!")
-                .currentPage(150)
-                .updateCount(1)
-                .startDate(LocalDate.of(2024, 11, 1))
-                .endDate(LocalDate.of(2024, 11, 20))
-                .build();
+            .member(reported)
+            .aladinBook(aladinBook)
+            .isbn13("9781234567890")
+            .status(BookStatus.READING)
+            .myRating(4.0)
+            .oneLineReview("Great book!")
+            .currentPage(150)
+            .updateCount(1)
+            .startDate(LocalDate.of(2024, 11, 1))
+            .endDate(LocalDate.of(2024, 11, 20))
+            .build();
         myBookRepository.save(myBook);
-        
+
         // Discussion 데이터 생성
         discussion = Discussion.builder()
-                .myBook(myBook)  // MyBook 객체 (책 정보)
-                .member(reported)  // 작성자 (Member 객체)
-                .title("책에 대해 어떻게 생각하시나요?")  // 토론 제목
-                .content("이 책은 정말 흥미롭고 생각할 거리를 많이 던져주는 작품입니다.")  // 토론 내용
-                .status(DiscussionStatus.PROPOSED)  // 토론 상태 (기본값 PROPOSED)
-                .startDate(LocalDateTime.now().plusDays(1))  // 최소 24시간 후로 설정
-                .views(0L)  // 조회수 (기본값 0)
-                .isDeleted(false)  // 삭제 여부 (기본값 false)
-                .build();
+            .myBook(myBook)  // MyBook 객체 (책 정보)
+            .member(reported)  // 작성자 (Member 객체)
+            .title("책에 대해 어떻게 생각하시나요?")  // 토론 제목
+            .content("이 책은 정말 흥미롭고 생각할 거리를 많이 던져주는 작품입니다.")  // 토론 내용
+            .status(DiscussionStatus.PROPOSED)  // 토론 상태 (기본값 PROPOSED)
+            .startDate(LocalDateTime.now().plusDays(1))  // 최소 24시간 후로 설정
+            .views(0L)  // 조회수 (기본값 0)
+            .isDeleted(false)  // 삭제 여부 (기본값 false)
+            .build();
         discussionRepository.save(discussion);
-        
+
         // DiscussionComment 데이터 생성
-        comment1 = DiscussionComment.builder()
-                .discussion(discussion)
-                .member(reporter)
-                .groupId(1L)
-                .parentId(0L)
-                .order(1L)
-                .isChild(false)
-                .totalOrder(1L)
-                .voteType(VoteType.AGREE)
-                .content("I agree with this point.")
-                .isSelected(false)
-                .discussionCommentStatus(DiscussionCommentStatus.ACTIVE)
-                .isDeleted(false)
-                .deletedAt(null)
-                .build();
-        
-        discussionCommentRepository.save(comment1);
-        
+        comment = DiscussionComment.builder()
+            .discussion(discussion)
+            .member(reporter)
+            .groupId(1L)
+            .parentId(0L)
+            .groupOrder(1L)
+            .isChild(false)
+            .totalOrder(1L)
+            .voteType(VoteType.AGREE)
+            .content("I agree with this point.")
+            .isSelected(false)
+            .discussionCommentStatus(DiscussionCommentStatus.ACTIVE)
+            .isDeleted(false)
+            .deletedAt(null)
+            .build();
+
+        discussionCommentRepository.save(comment);
+
         comment2 = DiscussionComment.builder()
-                .discussion(discussion)
-                .member(reporter2)
-                .groupId(1L)
-                .parentId(0L)
-                .order(2L)
-                .isChild(false)
-                .totalOrder(2L)
-                .voteType(VoteType.DISAGREE)
-                .content("I disagree with this point.")
-                .isSelected(false)
-                .discussionCommentStatus(DiscussionCommentStatus.ACTIVE)
-                .isDeleted(false)
-                .deletedAt(null)
-                .build();
-        
+            .discussion(discussion)
+            .member(reporter2)
+            .groupId(1L)
+            .parentId(0L)
+            .groupOrder(2L)
+            .isChild(false)
+            .totalOrder(2L)
+            .voteType(VoteType.DISAGREE)
+            .content("I disagree with this point.")
+            .isSelected(false)
+            .discussionCommentStatus(DiscussionCommentStatus.ACTIVE)
+            .isDeleted(false)
+            .deletedAt(null)
+            .build();
+
         discussionCommentRepository.save(comment2);
-        
+
         comment3 = DiscussionComment.builder()
-                .discussion(discussion)
-                .member(reported2)
-                .groupId(2L)
-                .parentId(1L)
-                .order(1L)
-                .isChild(true)
-                .totalOrder(3L)
-                .voteType(VoteType.AGREE)
-                .content("I support your view on this.")
-                .isSelected(false)
-                .discussionCommentStatus(DiscussionCommentStatus.ACTIVE)
-                .isDeleted(false)
-                .deletedAt(null)
-                .build();
-        
+            .discussion(discussion)
+            .member(reported2)
+            .groupId(2L)
+            .parentId(1L)
+            .groupOrder(1L)
+            .isChild(true)
+            .totalOrder(3L)
+            .voteType(VoteType.AGREE)
+            .content("I support your view on this.")
+            .isSelected(false)
+            .discussionCommentStatus(DiscussionCommentStatus.ACTIVE)
+            .isDeleted(false)
+            .deletedAt(null)
+            .build();
+
         discussionCommentRepository.save(comment3);
-        
+
+
         entityManager.flush();
         entityManager.clear();
     }
-    
+
     @Test
-    @DisplayName("토론 게시글 신고")
-    void reportDiscussion() {
-        // ReportRequestDTO 생성
-        ReportRequestDTO requestDTO = new ReportRequestDTO();
-        requestDTO.setDiscussionId(discussion.getId());  // 동일한 토론에 대해 신고
-        requestDTO.setReportedId(reported.getId()); // 신고된 사람 설정
-        requestDTO.setReason("기타");
-        requestDTO.setTargetType(String.valueOf(ReportTargetType.DISCUSSION));
-        
-        System.out.println("discussion = " + discussion.getStatus());
-        
-        // 1번 신고 실행
-        reportService.report(reporter.getId(), requestDTO); // 신고한 사람 설정
-        
-        // 2번 신고 실행 (동일한 discussion에 대해 다시 신고)
-        reportService.report(reporter2.getId(), requestDTO);
-        
-        // 3번 신고 실행 (동일한 discussion에 대해 다시 신고)
-        reportService.report(reported2.getId(), requestDTO);
-        
-        List<Report> all = reportRepository.findAll();
-        
-        System.out.println("all = " + all);
-        
-        entityManager.flush();
-        entityManager.clear();
-        
-        Discussion updatedDiscussion = discussionRepository.findById(discussion.getId()).orElseThrow();
-        
-        // 상태 확인
-        assertThat(updatedDiscussion.getStatus()).isEqualTo(DiscussionStatus.BLOCKED);  // 3회 신고 시 상태가 BLOCKED로 변경됨
-        
-        System.out.println("updatedDiscussion = " + updatedDiscussion.getStatus());
-    }
-    
-    @Test
-    @DisplayName("댓글 신고")
-    void reportComment() {
-        // ReportRequestDTO 생성
-        ReportRequestDTO requestDTO = new ReportRequestDTO();
-        requestDTO.setCommentId(comment1.getId());
-        requestDTO.setReportedId(reported.getId()); // 신고된 사람 설정
-        requestDTO.setReason("불법정보");
-        requestDTO.setTargetType(ReportTargetType.DISCUSSION_COMMENT.name());
-        
-        // 1번 신고 실행
-        reportService.report(reporter.getId(), requestDTO); // 신고한 사람 설정
-        
-        // 2번 신고 실행 (동일한 댓글에 대해 다시 신고)
-        reportService.report(reporter2.getId(), requestDTO);
-        
-        // 3번 신고 실행 (동일한 댓글에 대해 다시 신고)
-        reportService.report(reported2.getId(), requestDTO);
-        
-        entityManager.flush();
-        entityManager.clear();
-        
-        DiscussionComment discussionComment = discussionCommentRepository.findById(comment1.getId())
-                .orElseThrow();
-        
-        // 상태 확인
-        assertThat(discussionComment.getDiscussionCommentStatus()).isEqualTo(DiscussionCommentStatus.BLOCKED);  // 3회 신고 시 상태가 BLOCKED로 변경됨
-        
-        System.out.println("discussionComment = " + discussionComment.getDiscussionCommentStatus());
-    }
-    
-    @Test
-    @DisplayName("미처리 신고 목록을 페이징하여 조회한다")
-    void testGetPendingReportList() {
+    @DisplayName("토론 신고 테스트")
+    void testReportDiscussion() {
         // given
-        // 신고 데이터 생성 (토론글 신고)
-        List<Discussion> discussions = new ArrayList<>();
-        for (int i = 0; i < 3; i++) {
-            Discussion newDiscussion = Discussion.builder()
-                    .myBook(myBook)
-                    .member(reported)
-                    .title("토론 제목 " + i)
-                    .content("토론 내용 " + i)
-                    .status(DiscussionStatus.PROPOSED)
-                    .startDate(LocalDateTime.now().plusDays(1))
-                    .views(0L)
-                    .isDeleted(false)
-                    .build();
-            discussionRepository.save(newDiscussion);
-            discussions.add(newDiscussion);
-        }
-        
-        // 각 토론글에 대한 신고 생성
-        for (Discussion disc : discussions) {
-            ReportRequestDTO requestDTO = new ReportRequestDTO();
-            requestDTO.setDiscussionId(disc.getId());
-            requestDTO.setReportedId(reported.getId());
-            requestDTO.setReason("불법정보");
-            requestDTO.setTargetType(ReportTargetType.DISCUSSION.name());
-            
-            reportService.report(reporter.getId(), requestDTO);
-        }
-        
-        entityManager.flush();
-        entityManager.clear();
-        
+        ReportRequestDTO reportRequestDTO = ReportRequestDTO.builder()
+            .reason("부적절한 내용")
+            .build();
+
         // when
-        ScrollRequestDTO scrollRequestDTO = new ScrollRequestDTO();
-        scrollRequestDTO.setTabCondition("미처리");
-        scrollRequestDTO.setSort("desc");
-        scrollRequestDTO.setSize(2);
-        
-        ScrollResponseDTO<?> response = reportService.getReportList(scrollRequestDTO);
-        
+        reportService.reportDiscussion(reporter.getId(), discussion.getId(), reportRequestDTO);
+
         // then
-        assertThat(response.getContent()).hasSize(2); // size만큼만 조회되는지 확인
-        assertThat(response.isHasNext()).isTrue(); // 다음 페이지 존재 여부 확인
-        assertThat(response.getTotalElements()).isEqualTo(3L); // 전체 개수 확인
+        List<Report> reports = reportRepository.findAll();
+        assertThat(reports)
+            .hasSize(1)
+            .allSatisfy(report -> {
+                assertThat(report.getReporter().getId()).isEqualTo(reporter.getId());
+                assertThat(report.getReported().getId()).isEqualTo(reported.getId());
+                assertThat(report.getDiscussion().getId()).isEqualTo(discussion.getId());
+                assertThat(report.getReportReason()).isEqualTo("부적절한 내용");
+                assertThat(report.getStatus()).isEqualTo(ReportStatus.PENDING);
+                assertThat(report.getTargetType()).isEqualTo(ReportTargetType.DISCUSSION);
+            });
     }
-    
+
     @Test
-    @DisplayName("처리완료된 신고 목록을 페이징하여 조회한다")
-    void testGetCompletedReportList() {
+    @DisplayName("토론 신고 3회 이상 시 상태 변경 테스트")
+    void testReportDiscussionMoreThanThreeTimes() {
         // given
-        // 토론글 3개 생성
-        List<Discussion> discussions = new ArrayList<>();
+        ReportRequestDTO reportRequestDTO = new ReportRequestDTO();
+        reportRequestDTO.setReason("부적절한 내용");
+
+        // when
         for (int i = 0; i < 3; i++) {
-            Discussion newDiscussion = Discussion.builder()
-                    .myBook(myBook)
-                    .member(reported)
-                    .title("토론 제목 " + i)
-                    .content("토론 내용 " + i)
-                    .status(DiscussionStatus.PROPOSED)
-                    .startDate(LocalDateTime.now().plusDays(1))
-                    .views(0L)
-                    .isDeleted(false)
-                    .build();
-            discussionRepository.save(newDiscussion);
-            discussions.add(newDiscussion);
+            Member newReporter = Member.builder()
+                .username("reporter" + i + "@test.com")
+                .password("password")
+                .nickname("리포터" + i)
+                .build();
+            memberRepository.save(newReporter);
+            reportService.reportDiscussion(newReporter.getId(), discussion.getId(),
+                reportRequestDTO);
         }
-        
-        // 각 토론글에 대해 3번씩 신고하여 BLOCKED 상태로 만듦
-        for (Discussion disc : discussions) {
-            ReportRequestDTO requestDTO = new ReportRequestDTO();
-            requestDTO.setDiscussionId(disc.getId());
-            requestDTO.setReportedId(reported.getId());
-            requestDTO.setReason("불법정보");
-            requestDTO.setTargetType(ReportTargetType.DISCUSSION.name());
-            
-            reportService.report(reporter.getId(), requestDTO);
-            reportService.report(reporter2.getId(), requestDTO);
-            reportService.report(reported2.getId(), requestDTO);
+
+        // then
+        List<Report> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(3);
+        for (Report report : reports) {
+            assertThat(report.getStatus()).isEqualTo(ReportStatus.TEMPORARY_ACCEPTED);
         }
-        
+
+        Discussion blockedDiscussion = discussionRepository.findById(discussion.getId())
+            .orElseThrow();
+        assertThat(blockedDiscussion.getStatus()).isEqualTo(DiscussionStatus.BLOCKED);
+    }
+
+    @Test
+    @DisplayName("댓글 신고 테스트")
+    void testReportComment() {
+        // given
+        ReportRequestDTO reportRequestDTO = new ReportRequestDTO();
+        reportRequestDTO.setReason("부적절한 댓글");
+
+        // when
+        reportService.reportComment(reporter.getId(), comment.getId(), reportRequestDTO);
+
+        // 영속성 컨텍스트 동기화
         entityManager.flush();
         entityManager.clear();
-        
-        // when
-        ScrollRequestDTO scrollRequestDTO = new ScrollRequestDTO();
-        scrollRequestDTO.setTabCondition("미처리");
-        scrollRequestDTO.setSort("desc");
-        scrollRequestDTO.setSize(2);
-        
-        ScrollResponseDTO<?> response = reportService.getReportList(scrollRequestDTO);
-        
+
+        // given 객체 재조회
+        Member updatedReporter = memberRepository.findById(reporter.getId()).orElseThrow();
+        DiscussionComment updatedComment = discussionCommentRepository.findById(comment.getId())
+            .orElseThrow();
+
         // then
-        assertThat(response.getContent()).hasSize(2);
-        assertThat(response.isHasNext()).isTrue();
-        assertThat(response.getTotalElements()).isEqualTo(9L); // 3개의 토론글 * 3번의 신고 = 9
+        List<Report> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(1);
+
+        Report report = reports.get(0);
+        assertThat(report.getReporter().getId()).isEqualTo(updatedReporter.getId());
+        assertThat(report.getComment().getId()).isEqualTo(updatedComment.getId());
+        assertThat(report.getReportReason()).isEqualTo("부적절한 댓글");
+        assertThat(report.getStatus()).isEqualTo(ReportStatus.PENDING);
+        assertThat(report.getTargetType()).isEqualTo(ReportTargetType.DISCUSSION_COMMENT);
     }
-    
+
+    @Test
+    @DisplayName("댓글 신고 3회 이상 시 상태 변경 테스트")
+    void testReportCommentMoreThanThreeTimes() {
+        // given
+        ReportRequestDTO reportRequestDTO = new ReportRequestDTO();
+        reportRequestDTO.setReason("부적절한 댓글");
+
+        // when
+        for (int i = 0; i < 3; i++) {
+            Member newReporter = Member.builder()
+                .username("reporter" + i + "@test.com")
+                .password("password")
+                .nickname("리포터" + i)
+                .build();
+            memberRepository.save(newReporter);
+            reportService.reportComment(newReporter.getId(), comment.getId(), reportRequestDTO);
+        }
+
+        // then
+        List<Report> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(3);
+        for (Report report : reports) {
+            assertThat(report.getStatus()).isEqualTo(ReportStatus.TEMPORARY_ACCEPTED);
+        }
+
+        DiscussionComment blockedComment = discussionCommentRepository.findById(comment.getId())
+            .orElseThrow();
+        assertThat(blockedComment.getDiscussionCommentStatus()).isEqualTo(
+            DiscussionCommentStatus.BLOCKED);
+    }
+
+    @Test
+    @DisplayName("신고 목록 조회 테스트")
+    void testGetReportList() {
+        // given
+
+        // Report 데이터 생성
+        report = Report.builder()
+            .reporter(reporter)  // 신고한 사람 (Member 객체)
+            .reported(reported)  // 신고 당한 사람 (Member 객체)
+            .targetType(ReportTargetType.DISCUSSION)  // 신고 대상 타입 (토론)
+            .reportReason("불쾌감을 주는 내용")  // 신고 사유
+            .status(ReportStatus.PENDING)  // 신고 처리 상태 (PENDING, TEMPORARY_ACCEPTED, ACCEPTED, REJECTED)
+            .discussion(discussion)  // 신고 당한 토론 (Discussion 객체)
+            .build();
+        reportRepository.save(report);
+
+        report2 = Report.builder()
+            .reporter(reporter2)  // 신고한 사람 (Member 객체)
+            .reported(reported2)  // 신고 당한 사람 (Member 객체)
+            .targetType(ReportTargetType.DISCUSSION_COMMENT)  // 신고 대상 타입 (댓글)
+            .reportReason("부적절한 언행")  // 신고 사유
+            .status(ReportStatus.PENDING)  // 신고 처리 상태 (PENDING, TEMPORARY_ACCEPTED, ACCEPTED, REJECTED)
+            .comment(comment2)  // 신고 당한 댓글 (DiscussionComment 객체)
+            .build();
+        reportRepository.save(report2);
+
+        ScrollRequestDTO requestDTO = new ScrollRequestDTO();
+        requestDTO.setSize(10);
+        requestDTO.setLastId(0L);
+        requestDTO.setTabCondition("미처리");
+        requestDTO.setSort("desc");
+
+        // when
+        ScrollResponseDTO<ReportResponseDTO> result = reportService.getReportList(requestDTO);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+
+        // isHasNext() 검증 전에 현재 상태 출력
+        System.out.println("Content size: " + result.getContent().size());
+        System.out.println("Total elements: " + result.getTotalElements());
+        System.out.println("Has next: " + result.isHasNext());
+
+        assertThat(result.isHasNext()).isFalse();
+
+        // 추가적인 검증
+        assertThat(result.getContent())
+            .extracting("targetType")
+            .containsExactlyInAnyOrder(ReportTargetType.DISCUSSION, ReportTargetType.DISCUSSION_COMMENT);
+    }
+
     @Test
     @DisplayName("빈 목록을 조회한다")
     void testGetEmptyList() {
@@ -415,38 +421,38 @@ class ReportServiceImplTest {
         scrollRequestDTO.setTabCondition("미처리");
         scrollRequestDTO.setSort("desc");
         scrollRequestDTO.setSize(10);
-        
+
         // when
         ScrollResponseDTO<?> response = reportService.getReportList(scrollRequestDTO);
-        
+
         // then
         assertThat(response.getContent()).isEmpty();
         assertThat(response.isHasNext()).isFalse();
         assertThat(response.getTotalElements()).isEqualTo(0L);
     }
-    
+
     @Test
     @DisplayName("신고 상세 정보를 조회한다")
     void testGetReportDetail() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.PENDING)
-                .discussion(discussion)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.PENDING)
+            .discussion(discussion)
+            .build();
+
         Report savedReport = reportRepository.save(report);
         Long reportId = savedReport.getId();
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         ReportResponseDTO responseDTO = reportService.getReportDetail(reportId);
-        
+
         // then
         assertThat(responseDTO).isNotNull();
         assertThat(responseDTO.getId()).isEqualTo(reportId);
@@ -454,33 +460,35 @@ class ReportServiceImplTest {
         assertThat(responseDTO.getReportedNickname()).isEqualTo(reported.getNickname());
         assertThat(responseDTO.getReportReason()).isEqualTo("불법정보");
         assertThat(responseDTO.getTargetType()).isEqualTo(ReportTargetType.DISCUSSION);
-        assertThat(responseDTO.getDiscussionTitle()).isEqualTo(savedReport.getDiscussion().getTitle());
-        assertThat(responseDTO.getDiscussionContent()).isEqualTo(savedReport.getDiscussion().getContent());
+        assertThat(responseDTO.getDiscussionTitle()).isEqualTo(
+            savedReport.getDiscussion().getTitle());
+        assertThat(responseDTO.getDiscussionContent()).isEqualTo(
+            savedReport.getDiscussion().getContent());
         assertThat(responseDTO.getCommentContent()).isNull();  // Discussion 신고인 경우 commentId는 null
     }
-    
+
     @Test
     @DisplayName("댓글 신고 상세 정보를 조회한다")
     void testGetCommentReportDetail() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION_COMMENT)
-                .reportReason("불법정보")
-                .status(ReportStatus.PENDING)
-                .comment(comment1)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION_COMMENT)
+            .reportReason("불법정보")
+            .status(ReportStatus.PENDING)
+            .comment(comment)
+            .build();
+
         Report savedReport = reportRepository.save(report);
         Long reportId = savedReport.getId();
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         ReportResponseDTO responseDTO = reportService.getReportDetail(reportId);
-        
+
         // then
         assertThat(responseDTO).isNotNull();
         assertThat(responseDTO.getId()).isEqualTo(reportId);
@@ -489,246 +497,254 @@ class ReportServiceImplTest {
         assertThat(responseDTO.getReportReason()).isEqualTo("불법정보");
         assertThat(responseDTO.getTargetType()).isEqualTo(ReportTargetType.DISCUSSION_COMMENT);
         assertThat(responseDTO.getDiscussionTitle()).isNull();  // Comment 신고인 경우 discussionId는 null
-        assertThat(responseDTO.getDiscussionContent()).isNull();  // Comment 신고인 경우 discussionId는 null
-        assertThat(responseDTO.getCommentContent()).isEqualTo(comment1.getContent());
+        assertThat(
+            responseDTO.getDiscussionContent()).isNull();  // Comment 신고인 경우 discussionId는 null
+        assertThat(responseDTO.getCommentContent()).isEqualTo(comment.getContent());
     }
-    
+
     @Test
     @DisplayName("존재하지 않는 신고 ID로 조회시 예외가 발생한다")
     void testGetReportDetail_NotFound() {
         // given
         Long nonExistentReportId = 999L;
-        
+
         // when & then
         assertThatThrownBy(() -> reportService.getReportDetail(nonExistentReportId))
-                .isInstanceOf(ReportNotFoundException.class)
-                .hasMessageContaining("해당 report를 찾을 수 없습니다.");
+            .isInstanceOf(ReportNotFoundException.class)
+            .hasMessageContaining("해당 report를 찾을 수 없습니다.");
     }
-    
+
     @Test
     @DisplayName("PENDING 상태의 토론 신고를 거절하면 토론이 이전 상태로 복구된다")
     void testRejectPendingDiscussionReport() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.PENDING)
-                .discussion(discussion)
-                .previousDiscussionStatus(DiscussionStatus.PROPOSED)  // 이전 상태 저장
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.PENDING)
+            .discussion(discussion)
+            .previousDiscussionStatus(DiscussionStatus.PROPOSED)  // 이전 상태 저장
+            .build();
+
         Report savedReport = reportRepository.save(report);
         discussion.changeStatus(DiscussionStatus.BLOCKED);  // 토론 상태를 BLOCKED로 변경
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         reportService.rejectReport(savedReport.getId());
-        
+
         // then
         Report rejectedReport = reportRepository.findById(savedReport.getId()).orElseThrow();
-        Discussion updatedDiscussion = discussionRepository.findById(discussion.getId()).orElseThrow();
-        
+        Discussion updatedDiscussion = discussionRepository.findById(discussion.getId())
+            .orElseThrow();
+
         assertThat(rejectedReport.getStatus()).isEqualTo(ReportStatus.REJECTED);
         assertThat(updatedDiscussion.getStatus()).isEqualTo(DiscussionStatus.PROPOSED);
     }
-    
+
     @Test
     @DisplayName("TEMPORARY_ACCEPTED 상태의 토론 신고를 거절하면 토론이 이전 상태로 복구된다")
     void testRejectTemporaryAcceptedDiscussionReport() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.TEMPORARY_ACCEPTED)
-                .discussion(discussion)
-                .previousDiscussionStatus(DiscussionStatus.IN_PROGRESS)  // 이전 상태 저장
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.TEMPORARY_ACCEPTED)
+            .discussion(discussion)
+            .previousDiscussionStatus(DiscussionStatus.IN_PROGRESS)  // 이전 상태 저장
+            .build();
+
         Report savedReport = reportRepository.save(report);
         discussion.changeStatus(DiscussionStatus.BLOCKED);  // 토론 상태를 BLOCKED로 변경
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         reportService.rejectReport(savedReport.getId());
-        
+
         // then
         Report rejectedReport = reportRepository.findById(savedReport.getId()).orElseThrow();
-        Discussion updatedDiscussion = discussionRepository.findById(discussion.getId()).orElseThrow();
-        
+        Discussion updatedDiscussion = discussionRepository.findById(discussion.getId())
+            .orElseThrow();
+
         assertThat(rejectedReport.getStatus()).isEqualTo(ReportStatus.REJECTED);
         assertThat(updatedDiscussion.getStatus()).isEqualTo(DiscussionStatus.IN_PROGRESS);
     }
-    
+
     @Test
     @DisplayName("댓글 신고를 거절하면 댓글이 ACTIVE 상태로 복구된다")
     void testRejectCommentReport() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION_COMMENT)
-                .reportReason("불법정보")
-                .status(ReportStatus.TEMPORARY_ACCEPTED)
-                .comment(comment1)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION_COMMENT)
+            .reportReason("불법정보")
+            .status(ReportStatus.TEMPORARY_ACCEPTED)
+            .comment(comment)
+            .build();
+
         Report savedReport = reportRepository.save(report);
-        comment1.changeDiscussionCommentStatus(DiscussionCommentStatus.BLOCKED);
-        
+        comment.changeDiscussionCommentStatus(DiscussionCommentStatus.BLOCKED);
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         reportService.rejectReport(savedReport.getId());
-        
+
         // then
         Report rejectedReport = reportRepository.findById(savedReport.getId()).orElseThrow();
-        DiscussionComment updatedComment = discussionCommentRepository.findById(comment1.getId()).orElseThrow();
-        
+        DiscussionComment updatedComment = discussionCommentRepository.findById(comment.getId())
+            .orElseThrow();
+
         assertThat(rejectedReport.getStatus()).isEqualTo(ReportStatus.REJECTED);
-        assertThat(updatedComment.getDiscussionCommentStatus()).isEqualTo(DiscussionCommentStatus.ACTIVE);
+        assertThat(updatedComment.getDiscussionCommentStatus()).isEqualTo(
+            DiscussionCommentStatus.ACTIVE);
     }
-    
+
     @Test
     @DisplayName("이미 ACCEPTED나 REJECTED 상태인 신고는 거절할 수 없다")
     void testCannotRejectFinalizedReport() {
         // given
         Report acceptedReport = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.ACCEPTED)
-                .discussion(discussion)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.ACCEPTED)
+            .discussion(discussion)
+            .build();
+
         Report rejectedReport = Report.builder()
-                .reporter(reporter2)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.REJECTED)
-                .discussion(discussion)
-                .build();
-        
+            .reporter(reporter2)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.REJECTED)
+            .discussion(discussion)
+            .build();
+
         // 변수를 재할당하지 않고 새로운 변수에 저장
         Report savedAcceptedReport = reportRepository.save(acceptedReport);
         Report savedRejectedReport = reportRepository.save(rejectedReport);
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when & then
         assertThatThrownBy(() -> reportService.rejectReport(acceptedReport.getId()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("확정되지 않은 신고만 거절할 수 있습니다.");
-        
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("확정되지 않은 신고만 거절할 수 있습니다.");
+
         assertThatThrownBy(() -> reportService.rejectReport(rejectedReport.getId()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("확정되지 않은 신고만 거절할 수 있습니다.");
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("확정되지 않은 신고만 거절할 수 있습니다.");
     }
-    
+
     @Test
     @DisplayName("TEMPORARY_ACCEPTED 상태의 신고를 승인하면 ACCEPTED 상태가 되고 관련 콘텐츠가 차단된다")
     void testApproveTemporaryAcceptedReport() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.TEMPORARY_ACCEPTED)
-                .discussion(discussion)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.TEMPORARY_ACCEPTED)
+            .discussion(discussion)
+            .build();
+
         Report savedReport = reportRepository.save(report);
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         reportService.approvalReport(savedReport.getId());
-        
+
         // then
         Report approvedReport = reportRepository.findById(savedReport.getId()).orElseThrow();
-        Discussion blockedDiscussion = discussionRepository.findById(discussion.getId()).orElseThrow();
-        
+        Discussion blockedDiscussion = discussionRepository.findById(discussion.getId())
+            .orElseThrow();
+
         assertThat(approvedReport.getStatus()).isEqualTo(ReportStatus.ACCEPTED);
         assertThat(blockedDiscussion.getStatus()).isEqualTo(DiscussionStatus.BLOCKED);
     }
-    
+
     @Test
     @DisplayName("PENDING 상태의 신고를 승인하면 ACCEPTED 상태가 되고 관련 콘텐츠가 차단된다")
     void testApprovePendingReport() {
         // given
         Report report = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION_COMMENT)
-                .reportReason("불법정보")
-                .status(ReportStatus.PENDING)
-                .comment(comment1)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION_COMMENT)
+            .reportReason("불법정보")
+            .status(ReportStatus.PENDING)
+            .comment(comment)
+            .build();
+
         Report savedReport = reportRepository.save(report);
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when
         reportService.approvalReport(savedReport.getId());
-        
+
         // then
         Report approvedReport = reportRepository.findById(savedReport.getId()).orElseThrow();
-        DiscussionComment blockedComment = discussionCommentRepository.findById(comment1.getId()).orElseThrow();
-        
+        DiscussionComment blockedComment = discussionCommentRepository.findById(comment.getId())
+            .orElseThrow();
+
         assertThat(approvedReport.getStatus()).isEqualTo(ReportStatus.ACCEPTED);
-        assertThat(blockedComment.getDiscussionCommentStatus()).isEqualTo(DiscussionCommentStatus.BLOCKED);
+        assertThat(blockedComment.getDiscussionCommentStatus()).isEqualTo(
+            DiscussionCommentStatus.BLOCKED);
     }
-    
+
     @Test
     @DisplayName("이미 ACCEPTED나 REJECTED 상태인 신고는 승인할 수 없다")
     void testCannotApproveFinalizedReport() {
         // given
         Report acceptedReport = Report.builder()
-                .reporter(reporter)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.ACCEPTED)
-                .discussion(discussion)
-                .build();
-        
+            .reporter(reporter)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.ACCEPTED)
+            .discussion(discussion)
+            .build();
+
         Report rejectedReport = Report.builder()
-                .reporter(reporter2)
-                .reported(reported)
-                .targetType(ReportTargetType.DISCUSSION)
-                .reportReason("불법정보")
-                .status(ReportStatus.REJECTED)
-                .discussion(discussion)
-                .build();
-        
+            .reporter(reporter2)
+            .reported(reported)
+            .targetType(ReportTargetType.DISCUSSION)
+            .reportReason("불법정보")
+            .status(ReportStatus.REJECTED)
+            .discussion(discussion)
+            .build();
+
         Report savedAcceptedReport = reportRepository.save(acceptedReport);
         Report savedRejectedReport = reportRepository.save(rejectedReport);
-        
+
         entityManager.flush();
         entityManager.clear();
-        
+
         // when & then
         assertThatThrownBy(() -> reportService.approvalReport(savedAcceptedReport.getId()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("확정되지 않은 신고만 승인할 수 있습니다.");
-        
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("확정되지 않은 신고만 승인할 수 있습니다.");
+
         assertThatThrownBy(() -> reportService.approvalReport(savedRejectedReport.getId()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("확정되지 않은 신고만 승인할 수 있습니다.");
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("확정되지 않은 신고만 승인할 수 있습니다.");
     }
 }


### PR DESCRIPTION
- 댓글 달기 오류 수정 
답글 달기 시 totalOrder가 부모 댓글 바로 밑의 숫자로 변하지 않는 문제 수정
- 토론 출력 내용 수정 
토론에서는 신고를 위해 그 토론의 id값도 같이 출력을 해준다.
- 신고 하기 수정
토론, 댓글 신고를 하나의 신고로 처리 하였으나, 편의를 위해 토론, 댓글 두 가지의 컨트롤러를 활용하여 신고하기를 분류함.