### PR TITLE
fix(discussion, comment, MyBookRepository): 토론, 댓글, MyBookRepository 수정

### DIFF
--- a/src/main/java/com/undefinedus/backend/controller/DiscussionController.java
+++ b/src/main/java/com/undefinedus/backend/controller/DiscussionController.java
@@ -102,14 +102,11 @@ public class DiscussionController {
     @PatchMapping("/update")
     public ResponseEntity<ApiResponseDTO<Map<String, Long>>> discussionUpdate(
         @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO,
-        @RequestParam("isbn13") String isbn13,  // 수정할 책의 isbn13
-        @RequestParam("discussionId") Long discussionId,
         @Valid @RequestBody DiscussionUpdateRequestDTO discussionUpdateRequestDTO) throws Exception {
         
         Map<String, Long> result = new HashMap<>();
         
-        Long id = discussionService.discussionUpdate(memberSecurityDTO.getId(), isbn13, discussionId,
-                    discussionUpdateRequestDTO);
+        Long id = discussionService.discussionUpdate(memberSecurityDTO.getId(), discussionUpdateRequestDTO);
         result.put("id", id);
         
         return ResponseEntity.ok().body(ApiResponseDTO.success(result));

--- a/src/main/java/com/undefinedus/backend/dto/request/discussion/DiscussionUpdateRequestDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/request/discussion/DiscussionUpdateRequestDTO.java
@@ -9,6 +9,8 @@ import lombok.Data;
 @Builder
 public class DiscussionUpdateRequestDTO {
 
+    private Long discussionId;  // 수정 할 토론
+
     @NoProfanity
     private String title;    // 토론 제목
 

--- a/src/main/java/com/undefinedus/backend/dto/request/discussionComment/DiscussionCommentsScrollRequestDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/request/discussionComment/DiscussionCommentsScrollRequestDTO.java
@@ -19,4 +19,6 @@ public class DiscussionCommentsScrollRequestDTO {
     
     @Builder.Default
     private String sort = "asc"; // asc : 오름차순, desc : 내림차순
+
+    private Long discussionId; // 같은 토론의 댓글만 가져오려고 함
 }

--- a/src/main/java/com/undefinedus/backend/dto/response/aladinAPI/AladinApiResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/aladinAPI/AladinApiResponseDTO.java
@@ -33,8 +33,6 @@ public class AladinApiResponseDTO {
 
     private String fullDescription;
 
-    private String fullDescription2; // gpt에게 책의 추가적인 정보를 넘겨주기 위해 필요
-
     private String bestRank;   // 베스트셀러 순위 정보
 
     private SubInfoDTO subInfo;

--- a/src/main/java/com/undefinedus/backend/dto/response/discussionComment/DiscussionCommentResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/discussionComment/DiscussionCommentResponseDTO.java
@@ -14,6 +14,8 @@ public class DiscussionCommentResponseDTO {
 
     private Long memberId;
 
+    private String profileImage;
+
     private String nickname;
 
     private String honorific; // 칭호 = 초보리더 // version.1 에서는 기본 칭호를 유지할 예정

--- a/src/main/java/com/undefinedus/backend/repository/MyBookRepository.java
+++ b/src/main/java/com/undefinedus/backend/repository/MyBookRepository.java
@@ -36,7 +36,7 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long>, MyBookRep
             "JOIN member m ON mb.member_id = m.id " +
             "JOIN aladin_book ab ON mb.isbn13 = ab.isbn13 " +
             "WHERE m.id = :memberId " +
-            "ORDER BY ab.customer_review_rank DESC, ab.title ASC " +
+            "ORDER BY mb.my_rating DESC, ab.title ASC " +
             "LIMIT 5")
     List<String> findTop5Isbn13ByMemberId(@Param("memberId") Long memberId);
 

--- a/src/main/java/com/undefinedus/backend/repository/queryDSL/DiscussionCommentsRepositoryCustomImpl.java
+++ b/src/main/java/com/undefinedus/backend/repository/queryDSL/DiscussionCommentsRepositoryCustomImpl.java
@@ -26,6 +26,9 @@ public class DiscussionCommentsRepositoryCustomImpl implements DiscussionComment
         // 여러 조건들을 and()나 or()로 연결할 수 있게 해주는 빌더 패턴 구현체입니다
         BooleanBuilder builder = new BooleanBuilder();
 
+        // 같은 discussionId인 것만 가져오기
+        builder.and(qDiscussionComment.discussion.id.eq(requestDTO.getDiscussionId()));
+
         // cursor는 마지막으로 로드된 항목의 기준값(여기서는 ID)을 의미합니다
         // 이전/다음 페이지로 이동할 때 offset을 사용하는 대신 마지막으로 본 항목의 ID를 기준으로 데이터를 가져옵니다
         // Cursor 조건 추가

--- a/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
@@ -217,6 +217,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
             
             // 각 토론 댓글의 관련 정보를 추출
 
+            String profileImage = discussionComment.getMember().getProfileImage();
             Long groupId = discussionComment.getGroupId();
             Long commentId = discussionComment.getId();
             Long discussionId = discussionComment.getDiscussion().getId();
@@ -242,6 +243,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
                 .commentId(commentId)
                 .discussionId(discussionId)
                 .memberId(memberId)
+                .profileImage(profileImage)
                 .nickname(member.getNickname())
                 .honorific(member.getHonorific())
                 .parentId(parentId)
@@ -410,6 +412,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
             .orElseThrow(() -> new DiscussionParticipantNotFoundException("해당 참여자를 찾을 수 없습니다."));
     }
 
+    @Override
     public List<DiscussionCommentResponseDTO> getBest3CommentByCommentLikes(Long discussionId) {
 
         List<DiscussionComment> bestCommentTop3List = discussionCommentRepository.findBest3CommentList(
@@ -423,6 +426,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
         for (DiscussionComment discussionComment : bestCommentTop3List) {
             // 각 토론 댓글의 관련 정보를 추출
 
+            String profileImage = discussionComment.getMember().getProfileImage();
             Long commentId = discussionComment.getId();
             Long memberId = discussionComment.getMember().getId();
             Long parentId = discussionComment.getParentId();
@@ -446,6 +450,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
                 .commentId(commentId)
                 .discussionId(discussionId)
                 .memberId(memberId)
+                .profileImage(profileImage)
                 .nickname(member.getNickname())
                 .honorific(member.getHonorific())
                 .parentId(parentId)

--- a/src/main/java/com/undefinedus/backend/service/DiscussionService.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionService.java
@@ -22,8 +22,7 @@ public interface DiscussionService {
 
     DiscussionDetailResponseDTO getDiscussionDetail(Long loginMemgerId, Long discussionId);
 
-    Long discussionUpdate(Long memberId, String isbn13, Long discussionId,
-        DiscussionUpdateRequestDTO discussionUpdateRequestDTO) throws Exception;
+    Long discussionUpdate(Long memberId, DiscussionUpdateRequestDTO discussionUpdateRequestDTO) throws Exception;
 
     Map<String, String> joinAgree(Long memberId, Long discussionId);
     

--- a/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
@@ -225,14 +225,12 @@ public class DiscussionServiceImpl implements DiscussionService {
     }
 
     @Override
-    public Long discussionUpdate(Long memberId, String isbn13, Long discussionId,
-        DiscussionUpdateRequestDTO discussionUpdateRequestDTO) throws Exception {
+    public Long discussionUpdate(Long memberId, DiscussionUpdateRequestDTO discussionUpdateRequestDTO) throws Exception {
+
+        Long discussionId = discussionUpdateRequestDTO.getDiscussionId();
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException("해당 멤버를 찾을 수 없습니다. : " + memberId));
-
-        MyBook myBook = myBookRepository.findByMemberIdAndIsbn13(memberId, isbn13)
-            .orElseThrow(() -> new BookNotFoundException("해당 책을 찾을 수 없습니다. : " + isbn13));
 
         Discussion discussion = discussionRepository.findById(discussionId)
             .orElseThrow(
@@ -255,7 +253,6 @@ public class DiscussionServiceImpl implements DiscussionService {
         }
 
         // 토론 업데이트
-        discussion.changeMyBook(myBook);
         discussion.changeTitle(discussionUpdateRequestDTO.getTitle());
         discussion.changeContent(discussionUpdateRequestDTO.getContent());
 

--- a/src/test/java/com/undefinedus/backend/repository/MyBookRepositoryTests.java
+++ b/src/test/java/com/undefinedus/backend/repository/MyBookRepositoryTests.java
@@ -26,5 +26,7 @@ class MyBookRepositoryTests {
         List<String> top5Isbn13ByMemberId = myBookRepository.findTop5Isbn13ByMemberId(memberId);
         
         assertNotNull(top5Isbn13ByMemberId);
+
+        System.out.println("top5Isbn13ByMemberId = " + top5Isbn13ByMemberId);
     }
 }

--- a/src/test/java/com/undefinedus/backend/service/DiscussionCommentServiceImplTest.java
+++ b/src/test/java/com/undefinedus/backend/service/DiscussionCommentServiceImplTest.java
@@ -198,6 +198,7 @@ class DiscussionCommentServiceImplTest {
         DiscussionCommentsScrollRequestDTO requestDTO = new DiscussionCommentsScrollRequestDTO();
         requestDTO.setSize(10);
         requestDTO.setLastId(0L);
+        requestDTO.setDiscussionId(42L);
 
         Member member = new Member();
         member.setId(1L); // 멤버 ID 설정

--- a/src/test/java/com/undefinedus/backend/service/DiscussionServiceImplTest.java
+++ b/src/test/java/com/undefinedus/backend/service/DiscussionServiceImplTest.java
@@ -53,7 +53,7 @@ import org.quartz.SchedulerException;
 
 @ExtendWith(MockitoExtension.class)
 class DiscussionServiceImplTest {
-    
+
     @Mock
     private MemberRepository memberRepository;
     @Mock
@@ -70,156 +70,158 @@ class DiscussionServiceImplTest {
     private DiscussionParticipantRepository discussionParticipantRepository;
     @Mock
     private Scheduled scheduled;
-    
+
     @InjectMocks
     private DiscussionServiceImpl discussionServiceImpl;
-    
+
     private Long memberId;
     private String isbn13;
     private AladinBook mockAladinBook; // 추가
     private Member mockMember; // 추가
-    
+
     @BeforeEach
     void setUp() {
         memberId = 1L;
         isbn13 = "1234567890123";
-        
+
         // 공통으로 사용할 Mock 객체들 생성
         mockMember = Member.builder()
-                .id(memberId)
-                .nickname("testuser")
-                .honorific("테스터")
-                .build();
-        
+            .id(memberId)
+            .nickname("testuser")
+            .honorific("테스터")
+            .build();
+
         mockAladinBook = AladinBook.builder()
-                .isbn13(isbn13)
-                .title("Test Book")
-                .author("Test Author")
-                .cover("test-cover-url")
-                .build();
+            .isbn13(isbn13)
+            .title("Test Book")
+            .author("Test Author")
+            .cover("test-cover-url")
+            .build();
     }
-    
+
     // 통합된 createMockDiscussion 메서드
-    private Discussion createMockDiscussion(Long id, String title, int agreeCount, int disagreeCount, Member member, AladinBook aladinBook) {
+    private Discussion createMockDiscussion(Long id, String title, int agreeCount,
+        int disagreeCount, Member member, AladinBook aladinBook) {
         MyBook mockMyBook = MyBook.builder()
-                .id(id)
-                .isbn13(aladinBook.getIsbn13())
-                .member(member)
-                .aladinBook(aladinBook)
-                .status(BookStatus.COMPLETED)
-                .build();
-        
+            .id(id)
+            .isbn13(aladinBook.getIsbn13())
+            .member(member)
+            .aladinBook(aladinBook)
+            .status(BookStatus.COMPLETED)
+            .build();
+
         Discussion discussion = Discussion.builder()
-                .id(id)
-                .title(title)
-                .member(member)
-                .myBook(mockMyBook)
-                .aladinBook(aladinBook)
-                .content("Test content")
-                .status(DiscussionStatus.PROPOSED)
-                .startDate(LocalDateTime.now().plusDays(1))
-                .closedAt(LocalDateTime.now().plusDays(2))
-                .views(0L)
-                .isDeleted(false)
-                .build();
-        
+            .id(id)
+            .title(title)
+            .member(member)
+            .myBook(mockMyBook)
+            .aladinBook(aladinBook)
+            .content("Test content")
+            .status(DiscussionStatus.PROPOSED)
+            .startDate(LocalDateTime.now().plusDays(1))
+            .closedAt(LocalDateTime.now().plusDays(2))
+            .views(0L)
+            .isDeleted(false)
+            .build();
+
         if (agreeCount > 0 || disagreeCount > 0) {
             List<DiscussionParticipant> participants = new ArrayList<>();
             for (int i = 0; i < agreeCount; i++) {
                 participants.add(DiscussionParticipant.builder()
-                        .discussion(discussion)
-                        .member(member)
-                        .isAgree(true)
-                        .build());
+                    .discussion(discussion)
+                    .member(member)
+                    .isAgree(true)
+                    .build());
             }
             for (int i = 0; i < disagreeCount; i++) {
                 participants.add(DiscussionParticipant.builder()
-                        .discussion(discussion)
-                        .member(member)
-                        .isAgree(false)
-                        .build());
+                    .discussion(discussion)
+                    .member(member)
+                    .isAgree(false)
+                    .build());
             }
             discussion.changeParticipants(participants);
         }
-        
+
         return discussion;
     }
-    
+
     @Test
     @DisplayName("토론 생성 성공 테스트")
     void discussionRegister_shouldReturnDiscussionId() throws Exception {
         // Given
         LocalDateTime startDate = LocalDateTime.now().plusDays(1);
-        
+
         MyBook mockMyBook = MyBook.builder()
-                .id(1L)
-                .isbn13(isbn13)
-                .member(mockMember)
-                .aladinBook(mockAladinBook)
-                .status(BookStatus.COMPLETED)
-                .build();
-        
-        
+            .id(1L)
+            .isbn13(isbn13)
+            .member(mockMember)
+            .aladinBook(mockAladinBook)
+            .status(BookStatus.COMPLETED)
+            .build();
+
         DiscussionRegisterRequestDTO requestDTO = DiscussionRegisterRequestDTO.builder()
-                .isbn13(isbn13)
-                .title("Test Discussion Title")
-                .content("This is a test content for discussion.")
-                .startDate(startDate)
-                .build();
-        
+            .isbn13(isbn13)
+            .title("Test Discussion Title")
+            .content("This is a test content for discussion.")
+            .startDate(startDate)
+            .build();
+
         Discussion mockDiscussion = Discussion.builder()
-                .id(1L)
-                .myBook(mockMyBook)
-                .member(mockMember)
-                .aladinBook(mockAladinBook)
-                .title(requestDTO.getTitle())
-                .content(requestDTO.getContent())
-                .status(DiscussionStatus.PROPOSED)
-                .startDate(startDate)
-                .closedAt(startDate.plusDays(1))
-                .build();
-        
+            .id(1L)
+            .myBook(mockMyBook)
+            .member(mockMember)
+            .aladinBook(mockAladinBook)
+            .title(requestDTO.getTitle())
+            .content(requestDTO.getContent())
+            .status(DiscussionStatus.PROPOSED)
+            .startDate(startDate)
+            .closedAt(startDate.plusDays(1))
+            .build();
+
         // Mocking
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
-        when(myBookRepository.findByMemberIdAndIsbn13(memberId, isbn13)).thenReturn(Optional.of(mockMyBook));
+        when(myBookRepository.findByMemberIdAndIsbn13(memberId, isbn13)).thenReturn(
+            Optional.of(mockMyBook));
         when(discussionRepository.save(any(Discussion.class))).thenReturn(mockDiscussion);
         doNothing().when(quartzConfig).scheduleDiscussionJobs(any(LocalDateTime.class), anyLong());
-        
+
         // When
         Long discussionId = discussionServiceImpl.discussionRegister(memberId, requestDTO);
-        
+
         // Then
         assertNotNull(discussionId);
         assertEquals(1L, discussionId);
-        
+
         verify(memberRepository).findById(memberId);
         verify(myBookRepository).findByMemberIdAndIsbn13(memberId, isbn13);
         verify(discussionRepository).save(any(Discussion.class));
         verify(quartzConfig).scheduleDiscussionJobs(any(LocalDateTime.class), anyLong());
     }
-    
+
     @Test
     @DisplayName("토론 리스트 조회 테스트")
     void getDiscussionList_shouldReturnScrollResponseDTO() {
         // Given
         DiscussionScrollRequestDTO requestDTO = DiscussionScrollRequestDTO.builder()
-                .lastId(0L)
-                .size(10)
-                .sort("desc")
-                .status("PROPOSED")
-                .build();
-        
+            .lastId(0L)
+            .size(10)
+            .sort("desc")
+            .status("PROPOSED")
+            .build();
+
         List<Discussion> mockDiscussions = Arrays.asList(
-                createMockDiscussion(1L, "Discussion 1", 5, 3, mockMember, mockAladinBook),
-                createMockDiscussion(2L, "Discussion 2", 4, 2, mockMember, mockAladinBook)
+            createMockDiscussion(1L, "Discussion 1", 5, 3, mockMember, mockAladinBook),
+            createMockDiscussion(2L, "Discussion 2", 4, 2, mockMember, mockAladinBook)
         );
-        
+
         when(discussionRepository.findDiscussionsWithScroll(any(DiscussionScrollRequestDTO.class)))
-                .thenReturn(mockDiscussions);
-        
+            .thenReturn(mockDiscussions);
+
         // When
-        ScrollResponseDTO<DiscussionListResponseDTO> result = discussionServiceImpl.getDiscussionList(requestDTO);
-        
+        ScrollResponseDTO<DiscussionListResponseDTO> result = discussionServiceImpl.getDiscussionList(
+            requestDTO);
+
         // Then
         assertNotNull(result);
         assertEquals(2, result.getContent().size());
@@ -227,14 +229,15 @@ class DiscussionServiceImplTest {
         assertEquals(2, result.getNumberOfElements());
         assertEquals(2L, result.getLastId());
         assertFalse(result.isHasNext());
-        
+
         DiscussionListResponseDTO firstDiscussion = result.getContent().get(0);
         assertEquals(1L, firstDiscussion.getDiscussionId());
         assertEquals("Discussion 1", firstDiscussion.getTitle());
         assertEquals(5L, firstDiscussion.getAgree());
         assertEquals(3L, firstDiscussion.getDisagree());
-        
-        ArgumentCaptor<DiscussionScrollRequestDTO> captor = ArgumentCaptor.forClass(DiscussionScrollRequestDTO.class);
+
+        ArgumentCaptor<DiscussionScrollRequestDTO> captor = ArgumentCaptor.forClass(
+            DiscussionScrollRequestDTO.class);
         verify(discussionRepository).findDiscussionsWithScroll(captor.capture());
         DiscussionScrollRequestDTO capturedDTO = captor.getValue();
         assertEquals(0L, capturedDTO.getLastId());
@@ -242,146 +245,139 @@ class DiscussionServiceImplTest {
         assertEquals("desc", capturedDTO.getSort());
         assertEquals("PROPOSED", capturedDTO.getStatus());
     }
+
     @Test
     @DisplayName("토론 수정 성공 테스트")
     void discussionModify_shouldModifyDiscussion() throws Exception {
         // Given
         Long discussionId = 10L;
-        
-        MyBook mockMyBook = MyBook.builder()
-                .id(1L)
-                .isbn13(isbn13)
-                .member(mockMember)
-                .aladinBook(mockAladinBook)
-                .status(BookStatus.COMPLETED)
-                .build();
-        
+
         Discussion mockDiscussion = Discussion.builder()
-                .id(discussionId)
-                .member(mockMember)
-                .myBook(mockMyBook)
-                .aladinBook(mockAladinBook)
-                .status(DiscussionStatus.PROPOSED)
-                .build();
-        
+            .id(discussionId)
+            .member(mockMember)
+            .status(DiscussionStatus.PROPOSED)
+            .build();
+
         DiscussionUpdateRequestDTO requestDTO = DiscussionUpdateRequestDTO.builder()
-                .title("Updated Title")
-                .content("Updated Content")
-                .modifyStartTime(LocalDateTime.now().plusHours(2))
-                .build();
-        
+            .discussionId(discussionId)
+            .title("Updated Title")
+            .content("Updated Content")
+            .modifyStartTime(LocalDateTime.now().plusHours(2))
+            .build();
+
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
-        when(myBookRepository.findByMemberIdAndIsbn13(memberId, isbn13)).thenReturn(Optional.of(mockMyBook));
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(mockDiscussion));
         when(discussionRepository.save(any(Discussion.class))).thenReturn(mockDiscussion);
-        
+
         // When
-        Long modifiedDiscussionId = discussionServiceImpl.discussionUpdate(memberId, isbn13, discussionId, requestDTO);
-        
+        Long modifiedDiscussionId = discussionServiceImpl.discussionUpdate(memberId, requestDTO);
+
         // Then
         assertNotNull(modifiedDiscussionId);
         assertEquals(discussionId, modifiedDiscussionId);
         assertEquals("Updated Title", mockDiscussion.getTitle());
         assertEquals("Updated Content", mockDiscussion.getContent());
-        
+
         verify(discussionRepository).save(any(Discussion.class));
     }
-    
+
     @Test
     @DisplayName("찬성 참여 성공 테스트")
     void joinAgree_shouldSaveDiscussionParticipant() {
         // Given
         Long discussionId = 5L;
-        
+
         Discussion mockDiscussion = Discussion.builder()
-                .id(discussionId)
+            .id(discussionId)
+            .member(mockMember)
+            .myBook(MyBook.builder()
                 .member(mockMember)
-                .myBook(MyBook.builder()
-                        .member(mockMember)
-                        .aladinBook(mockAladinBook)
-                        .build())
                 .aladinBook(mockAladinBook)
-                .status(DiscussionStatus.PROPOSED)
-                .build();
-        
+                .build())
+            .aladinBook(mockAladinBook)
+            .status(DiscussionStatus.PROPOSED)
+            .build();
+
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(mockDiscussion));
-        
+
         // When
         discussionServiceImpl.joinAgree(memberId, discussionId);
-        
+
         // Then
-        ArgumentCaptor<DiscussionParticipant> captor = ArgumentCaptor.forClass(DiscussionParticipant.class);
+        ArgumentCaptor<DiscussionParticipant> captor = ArgumentCaptor.forClass(
+            DiscussionParticipant.class);
         verify(discussionParticipantRepository).save(captor.capture());
-        
+
         DiscussionParticipant savedParticipant = captor.getValue();
         assertEquals(mockDiscussion, savedParticipant.getDiscussion());
         assertEquals(mockMember, savedParticipant.getMember());
         assertTrue(savedParticipant.isAgree());
     }
-    
+
     @Test
     @DisplayName("반대 참여 성공 테스트")
     void joinDisagree_shouldSaveDiscussionParticipant() {
         // Given
         Long discussionId = 5L;
-        
+
         Discussion mockDiscussion = Discussion.builder()
-                .id(discussionId)
+            .id(discussionId)
+            .member(mockMember)
+            .myBook(MyBook.builder()
                 .member(mockMember)
-                .myBook(MyBook.builder()
-                        .member(mockMember)
-                        .aladinBook(mockAladinBook)
-                        .build())
                 .aladinBook(mockAladinBook)
-                .status(DiscussionStatus.PROPOSED)
-                .build();
-        
+                .build())
+            .aladinBook(mockAladinBook)
+            .status(DiscussionStatus.PROPOSED)
+            .build();
+
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(mockDiscussion));
-        
+
         // When
         discussionServiceImpl.joinDisagree(memberId, discussionId);
-        
+
         // Then
-        ArgumentCaptor<DiscussionParticipant> captor = ArgumentCaptor.forClass(DiscussionParticipant.class);
+        ArgumentCaptor<DiscussionParticipant> captor = ArgumentCaptor.forClass(
+            DiscussionParticipant.class);
         verify(discussionParticipantRepository).save(captor.capture());
-        
+
         DiscussionParticipant savedParticipant = captor.getValue();
         assertEquals(mockDiscussion, savedParticipant.getDiscussion());
         assertEquals(mockMember, savedParticipant.getMember());
         assertFalse(savedParticipant.isAgree());
     }
-    
+
     @Test
     @DisplayName("토론 삭제 성공 테스트")
     void deleteDiscussion_shouldDeleteDiscussion() throws SchedulerException {
         // Given
         Long discussionId = 5L;
-        
+
         Discussion mockDiscussion = Discussion.builder()
-                .id(discussionId)
+            .id(discussionId)
+            .member(mockMember)
+            .myBook(MyBook.builder()
                 .member(mockMember)
-                .myBook(MyBook.builder()
-                        .member(mockMember)
-                        .aladinBook(mockAladinBook)
-                        .build())
                 .aladinBook(mockAladinBook)
-                .status(DiscussionStatus.PROPOSED)
-                .views(0L)
-                .isDeleted(false)
-                .build();
-        
+                .build())
+            .aladinBook(mockAladinBook)
+            .status(DiscussionStatus.PROPOSED)
+            .views(0L)
+            .isDeleted(false)
+            .build();
+
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(mockDiscussion));
         doNothing().when(quartzConfig).removeJob(anyLong());
-        
+
         // When
         discussionServiceImpl.deleteDiscussion(memberId, discussionId);
-        
+
         // Then
         verify(discussionRepository).findById(discussionId);
         verify(quartzConfig).removeJob(discussionId);
-        
+
         assertTrue(mockDiscussion.isDeleted());
         assertNotNull(mockDiscussion.getDeletedAt());
     }


### PR DESCRIPTION
- 토론 수정 시 필요한 정보 수정 토론 수정 시 myBook 항목 삭제
- MyBookRepository 쿼리 수정
- 댓글 목록 정보 수정 댓글 목록에서 회원의 프로필 출력, 이전에는 댓글 목록이 토론 게시물 상관없이 모든 댓글이 나왔으나 해당 토론의 댓글만 출력되게 수정