### PR TITLE
fix(discussion): 탈퇴한 회원이 작성하였을 경우에 대한 코드 업데이트

### DIFF
--- a/src/main/java/com/undefinedus/backend/controller/DiscussionCommentController.java
+++ b/src/main/java/com/undefinedus/backend/controller/DiscussionCommentController.java
@@ -75,14 +75,15 @@ public class DiscussionCommentController {
     }
 
     // 댓글 리스트
-    @GetMapping
+    @GetMapping("/{discussionId}")
     public ResponseEntity<ApiResponseDTO<ScrollResponseDTO<DiscussionCommentResponseDTO>>> getCommentList(
             @AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO,
+            @PathVariable("discussionId") Long discussionId,
             @ModelAttribute DiscussionCommentsScrollRequestDTO requestDTO
     ) {
         
         ScrollResponseDTO<DiscussionCommentResponseDTO> response = discussionCommentService.getCommentList(
-            memberSecurityDTO.getId(), requestDTO);
+            memberSecurityDTO.getId(), requestDTO, discussionId);
 
         return ResponseEntity.ok(ApiResponseDTO.success(response));
     }

--- a/src/main/java/com/undefinedus/backend/controller/MemberController.java
+++ b/src/main/java/com/undefinedus/backend/controller/MemberController.java
@@ -25,6 +25,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -133,5 +134,11 @@ public class MemberController {
                 "status", "error",
                 "message", "잘못된 인증 코드이거나 만료되었습니다."
         );
+    }
+    
+    @DeleteMapping
+    public ResponseEntity<ApiResponseDTO<Void>> deleteMember(@AuthenticationPrincipal MemberSecurityDTO memberSecurityDTO) {
+        memberService.deleteMember(memberSecurityDTO.getId());
+        return ResponseEntity.ok(ApiResponseDTO.success(null));
     }
 }

--- a/src/main/java/com/undefinedus/backend/domain/entity/Discussion.java
+++ b/src/main/java/com/undefinedus/backend/domain/entity/Discussion.java
@@ -24,6 +24,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
@@ -46,6 +48,7 @@ public class Discussion extends BaseEntity {
     private AladinBook aladinBook;
     
     @ManyToOne(fetch = FetchType.LAZY)
+    @NotFound(action = NotFoundAction.IGNORE)  // 추가
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;  // 작성자
 

--- a/src/main/java/com/undefinedus/backend/domain/entity/DiscussionComment.java
+++ b/src/main/java/com/undefinedus/backend/domain/entity/DiscussionComment.java
@@ -21,6 +21,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -45,6 +47,7 @@ public class DiscussionComment extends BaseEntity {
     private Discussion discussion;  // 어떤 토론의 댓글인지
     
     @ManyToOne(fetch = FetchType.LAZY)
+    @NotFound(action = NotFoundAction.IGNORE)  // 추가
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;  // 작성자
     

--- a/src/main/java/com/undefinedus/backend/domain/entity/Member.java
+++ b/src/main/java/com/undefinedus/backend/domain/entity/Member.java
@@ -48,14 +48,13 @@ public class Member extends BaseEntity {
     private Long id;
 
     // === 기본 정보 === //
-    @Column(length = 40, unique = true, nullable = false)
+    @Column(length = 50, unique = true, nullable = false)   // 회원탈퇴시 처리를 위해 length 50으로 변경
     private String username;    // 아이디 (일반 로그인 유저 : 이메일형식, 소셜 로그인 유저 : 숫자형식(kakaoId))
 
     @Column(length = 100, nullable = false) // 암호화해서 길이 늘어남
     private String password;   // 비밀번호
 
-    @Column(length = 10, unique = true, nullable = false)
-    @Size(min = 2, max = 10)
+    @Column(length = 50, unique = true, nullable = false)  // 회원탈퇴시 처리를 위해 length 50으로 변경
     private String nickname;    // 일반, 소셜 둘다 회원 가입시 임의 작성
 
     // === 프로필 정보 === //
@@ -164,8 +163,7 @@ public class Member extends BaseEntity {
         this.gender = gender;
     }
 
-    public void setNickname(
-        @Size(min = 2, max = 10) String nickname) {
+    public void setNickname(String nickname) {
         this.nickname = nickname;
     }
 
@@ -208,5 +206,13 @@ public class Member extends BaseEntity {
     
     public void updateDeletedAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
+    }
+    
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+    
+    public void updateUsername(String username) {
+        this.username = username;
     }
 }

--- a/src/main/java/com/undefinedus/backend/dto/request/discussionComment/DiscussionCommentsScrollRequestDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/request/discussionComment/DiscussionCommentsScrollRequestDTO.java
@@ -19,6 +19,4 @@ public class DiscussionCommentsScrollRequestDTO {
     
     @Builder.Default
     private String sort = "asc"; // asc : 오름차순, desc : 내림차순
-
-    private Long discussionId; // 같은 토론의 댓글만 가져오려고 함
 }

--- a/src/main/java/com/undefinedus/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/undefinedus/backend/repository/DiscussionRepository.java
@@ -5,6 +5,7 @@ import com.undefinedus.backend.repository.queryDSL.DiscussionRepositoryCustom;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,4 +17,11 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long>,
 
     @Query("SELECT d FROM Discussion d LEFT JOIN FETCH d.participants WHERE d.id = :discussionId")
     Optional<Discussion> findByIdWithParticipants(@Param("discussionId") Long discussionId);
+    
+    @Modifying
+    @Query("UPDATE Discussion d SET d.views = d.views + 1 WHERE d.id = :discussionId")
+    void increaseViews(@Param("discussionId") Long discussionId);
+    
+    @Query("SELECT d.views FROM Discussion d WHERE d.id = :discussionId")
+    Long findViewsById(@Param("discussionId") Long discussionId);
 }

--- a/src/main/java/com/undefinedus/backend/repository/queryDSL/DiscussionCommentsRepositoryCustom.java
+++ b/src/main/java/com/undefinedus/backend/repository/queryDSL/DiscussionCommentsRepositoryCustom.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface DiscussionCommentsRepositoryCustom {
 
-    List<DiscussionComment> findDiscussionCommentListWithScroll(DiscussionCommentsScrollRequestDTO requestDTO);
+    List<DiscussionComment> findDiscussionCommentListWithScroll(DiscussionCommentsScrollRequestDTO requestDTO,
+            Long discussionId);
 }

--- a/src/main/java/com/undefinedus/backend/repository/queryDSL/DiscussionCommentsRepositoryCustomImpl.java
+++ b/src/main/java/com/undefinedus/backend/repository/queryDSL/DiscussionCommentsRepositoryCustomImpl.java
@@ -18,7 +18,7 @@ public class DiscussionCommentsRepositoryCustomImpl implements DiscussionComment
     private final JPAQueryFactory queryFactory;
     
     public List<DiscussionComment> findDiscussionCommentListWithScroll(
-        DiscussionCommentsScrollRequestDTO requestDTO) {
+        DiscussionCommentsScrollRequestDTO requestDTO, Long discussionId) {
         QDiscussionComment qDiscussionComment = QDiscussionComment.discussionComment;
         
         // 기본 쿼리 생성
@@ -27,7 +27,7 @@ public class DiscussionCommentsRepositoryCustomImpl implements DiscussionComment
         BooleanBuilder builder = new BooleanBuilder();
 
         // 같은 discussionId인 것만 가져오기
-        builder.and(qDiscussionComment.discussion.id.eq(requestDTO.getDiscussionId()));
+        builder.and(qDiscussionComment.discussion.id.eq(discussionId));
 
         // cursor는 마지막으로 로드된 항목의 기준값(여기서는 ID)을 의미합니다
         // 이전/다음 페이지로 이동할 때 offset을 사용하는 대신 마지막으로 본 항목의 ID를 기준으로 데이터를 가져옵니다

--- a/src/main/java/com/undefinedus/backend/service/DiscussionCommentService.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionCommentService.java
@@ -15,7 +15,7 @@ public interface DiscussionCommentService {
         DiscussionCommentRequestDTO discussionCommentRequestDTO);
 
     ScrollResponseDTO<DiscussionCommentResponseDTO> getCommentList(
-        Long loginMemberId, DiscussionCommentsScrollRequestDTO discussionCommentsScrollRequestDTO);
+        Long loginMemberId, DiscussionCommentsScrollRequestDTO discussionCommentsScrollRequestDTO, Long discussionId);
 
     void addLike(Long memberId, Long discussionCommentId);
 

--- a/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
@@ -192,10 +192,10 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
 
     @Override
     public ScrollResponseDTO<DiscussionCommentResponseDTO> getCommentList(
-        Long loginMemberId, DiscussionCommentsScrollRequestDTO discussionCommentsScrollRequestDTO) {
+        Long loginMemberId, DiscussionCommentsScrollRequestDTO discussionCommentsScrollRequestDTO, Long discussionId) {
 
         List<DiscussionComment> discussionCommentList = discussionCommentRepository.findDiscussionCommentListWithScroll(
-            discussionCommentsScrollRequestDTO);
+            discussionCommentsScrollRequestDTO, discussionId);
 
         boolean hasNext = false;
         if (discussionCommentList.size()
@@ -216,12 +216,17 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
             boolean isReport = reportedCommentIds.contains(discussionComment.getId());
             
             // 각 토론 댓글의 관련 정보를 추출
-
-            String profileImage = discussionComment.getMember().getProfileImage();
+            
+            Long memberId = discussionComment.getMember() == null ? -1L : discussionComment.getMember().getId();
+            String profileImage =
+                    discussionComment.getMember() == null ? "defaultProfileImage.jpg" : discussionComment.getMember().getProfileImage();
+            String nickname =
+                    discussionComment.getMember() == null ? "탈퇴한 사용자" : discussionComment.getMember().getNickname();
+            String honorific =
+                    discussionComment.getMember() == null ? "돌아와요" : discussionComment.getMember().getHonorific();
+            
             Long groupId = discussionComment.getGroupId();
             Long commentId = discussionComment.getId();
-            Long discussionId = discussionComment.getDiscussion().getId();
-            Long memberId = discussionComment.getMember().getId();
             Long parentId = discussionComment.getParentId();
             Long order = discussionComment.getGroupOrder();
             boolean isChild = discussionComment.isChild();
@@ -235,17 +240,14 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
             Long totalOrder = discussionComment.getTotalOrder();
             DiscussionCommentStatus discussionCommentStatus = discussionComment.getDiscussionCommentStatus();
 
-            Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("해당 멤버를 찾을 수 없습니다. : " + memberId));
-
             // DTO 객체 생성 후 리스트에 추가
             DiscussionCommentResponseDTO dto = DiscussionCommentResponseDTO.builder()
                 .commentId(commentId)
                 .discussionId(discussionId)
                 .memberId(memberId)
                 .profileImage(profileImage)
-                .nickname(member.getNickname())
-                .honorific(member.getHonorific())
+                .nickname(nickname)
+                .honorific(honorific)
                 .parentId(parentId)
                 .groupId(groupId)
                 .groupOrder(order)
@@ -425,10 +427,16 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
 
         for (DiscussionComment discussionComment : bestCommentTop3List) {
             // 각 토론 댓글의 관련 정보를 추출
+            
+            Long memberId = discussionComment.getMember() == null ? -1L : discussionComment.getMember().getId();
+            String profileImage =
+                    discussionComment.getMember() == null ? "defaultProfileImage.jpg" : discussionComment.getMember().getProfileImage();
+            String nickname =
+                    discussionComment.getMember() == null ? "탈퇴한 사용자" : discussionComment.getMember().getNickname();
+            String honorific =
+                    discussionComment.getMember() == null ? "돌아와요" : discussionComment.getMember().getHonorific();
 
-            String profileImage = discussionComment.getMember().getProfileImage();
             Long commentId = discussionComment.getId();
-            Long memberId = discussionComment.getMember().getId();
             Long parentId = discussionComment.getParentId();
             Long order = discussionComment.getGroupOrder();
             boolean isChild = discussionComment.isChild();
@@ -442,17 +450,14 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
             Long totalOrder = discussionComment.getTotalOrder();
             DiscussionCommentStatus discussionCommentStatus = discussionComment.getDiscussionCommentStatus();
 
-            Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("해당 멤버를 찾을 수 없습니다. : " + memberId));
-
             // DTO 객체 생성 후 리스트에 추가
             DiscussionCommentResponseDTO dto = DiscussionCommentResponseDTO.builder()
                 .commentId(commentId)
                 .discussionId(discussionId)
                 .memberId(memberId)
                 .profileImage(profileImage)
-                .nickname(member.getNickname())
-                .honorific(member.getHonorific())
+                .nickname(nickname)
+                .honorific(honorific)
                 .parentId(parentId)
                 .groupOrder(order)
                 .totalOrder(totalOrder)

--- a/src/main/java/com/undefinedus/backend/service/MemberService.java
+++ b/src/main/java/com/undefinedus/backend/service/MemberService.java
@@ -51,5 +51,6 @@ public interface MemberService {
             "일반"  // 일반 로그인 사용자
         );
     }
-
+    
+    void deleteMember(Long loginMemberId);
 }

--- a/src/main/java/com/undefinedus/backend/service/MemberServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/MemberServiceImpl.java
@@ -9,13 +9,16 @@ import com.undefinedus.backend.dto.request.social.RegisterRequestDTO;
 import com.undefinedus.backend.exception.member.MemberNotFoundException;
 import com.undefinedus.backend.repository.MemberRepository;
 import com.undefinedus.backend.util.JWTUtil;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -152,7 +155,29 @@ public class MemberServiceImpl implements MemberService {
         }
 
     }
-
+    
+    @Override
+    public void deleteMember(Long loginMemberId) {
+        
+        Member member = memberRepository.findById(loginMemberId)
+                .orElseThrow(() -> new MemberNotFoundException("해당 member를 찾을 수 없습니다. : " + loginMemberId));
+        
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        String withdrawnSuffix = String.format("(탈퇴회원-%s)", uuid);
+        
+        try {
+            member.updateDeleted(true);
+            member.updateDeletedAt(LocalDateTime.now());
+            member.updateUsername(member.getUsername() + withdrawnSuffix);
+            member.updateNickname(member.getNickname() + withdrawnSuffix);
+        } catch (
+            DataIntegrityViolationException e) {
+            // 혹시 모를 unique 제약조건 위반 대비
+            throw new RuntimeException("회원 탈퇴 처리 중 오류가 발생했습니다.", e);
+        }
+    
+    }
+    
     private Member makeSocialMember(RegisterRequestDTO requestDTO) {
 
         // 소셜 로그인 비밀번호는 사용자가 사용하진 않지만 최소한의 보안은 하도록 아래처럼

--- a/src/test/java/com/undefinedus/backend/service/DiscussionCommentServiceImplTest.java
+++ b/src/test/java/com/undefinedus/backend/service/DiscussionCommentServiceImplTest.java
@@ -191,37 +191,42 @@ class DiscussionCommentServiceImplTest {
         verify(discussionCommentRepository, times(1)).save(any(DiscussionComment.class));
         verify(discussionCommentRepository, times(1)).incrementTotalOrderFrom(anyLong());
     }
-
+    
     @Test
     @DisplayName("댓글 목록을 스크롤 방식으로 조회하는 테스트")
     void testGetCommentList() {
+        // Given
         DiscussionCommentsScrollRequestDTO requestDTO = new DiscussionCommentsScrollRequestDTO();
         requestDTO.setSize(10);
         requestDTO.setLastId(0L);
-        requestDTO.setDiscussionId(42L);
-
+        
+        Long discussionId = 42L;
+        
         Member member = new Member();
-        member.setId(1L); // 멤버 ID 설정
-
+        member.setId(1L);
+        
         Discussion discussion = new Discussion();
-        discussion.changeId(1L); // 토론 ID 설정
-
+        discussion.changeId(1L);
+        
         DiscussionComment comment1 = DiscussionComment.builder()
-            .id(1L)
-            .discussion(discussion)
-            .member(member)
-            .voteType(VoteType.AGREE)
-            .content("Test Comment")
-            .build();
-
+                .id(1L)
+                .discussion(discussion)
+                .member(member)
+                .voteType(VoteType.AGREE)
+                .content("Test Comment")
+                .build();
+        
         List<DiscussionComment> commentList = Arrays.asList(comment1);
-
-        when(discussionCommentRepository.findDiscussionCommentListWithScroll(any())).thenReturn(commentList);
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member)); // 정확한 멤버 ID로 설정
-
+        
+        // When
+        when(discussionCommentRepository.findDiscussionCommentListWithScroll(any(DiscussionCommentsScrollRequestDTO.class), eq(discussionId)))
+                .thenReturn(commentList);
+        when(memberRepository.findById(eq(1L))).thenReturn(Optional.of(member));
+        
         ScrollResponseDTO<DiscussionCommentResponseDTO> result =
-                discussionCommentService.getCommentList(member.getId(), requestDTO);
-
+                discussionCommentService.getCommentList(member.getId(), requestDTO, discussionId);
+        
+        // Then
         assertNotNull(result);
         assertEquals(1, result.getContent().size());
         assertFalse(result.isHasNext());


### PR DESCRIPTION
- Member 엔티티에 소프트 딜리트 시 username, nickname 업데이트 로직 추가
- Discussion 조회수 증가 로직 개선으로 member_id null 오류 해결
  - 더티체킹 대신 직접 쿼리 사용하도록 변경
  - 조회수 증가와 조회를 위한 별도 쿼리 추가
- 관련 테스트 코드 수정