### PR TITLE
fix(discussion): Blocked 된 게시물 관련 기능 업데이트

### DIFF
--- a/src/main/java/com/undefinedus/backend/domain/entity/Discussion.java
+++ b/src/main/java/com/undefinedus/backend/domain/entity/Discussion.java
@@ -1,6 +1,7 @@
 package com.undefinedus.backend.domain.entity;
 
 import com.undefinedus.backend.domain.enums.DiscussionStatus;
+import com.undefinedus.backend.domain.enums.ViewStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -109,6 +110,11 @@ public class Discussion extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Long views = 0L;    // 조회수 기본값 0으로 초기화
+    
+    // == Blocked 되었는지 관련 == //
+    @Column(nullable = false)
+    @Builder.Default
+    private ViewStatus viewStatus = ViewStatus.ACTIVE;
 
     // === Soft Delete 관련 === //
     @Column(nullable = false)
@@ -186,5 +192,9 @@ public class Discussion extends BaseEntity {
 
     public void changeReasoning(String reasoning) {
         this.reasoning = reasoning;
+    }
+    
+    public void changeViewStatus(ViewStatus viewStatus) {
+        this.viewStatus = viewStatus;
     }
 }

--- a/src/main/java/com/undefinedus/backend/domain/enums/DiscussionStatus.java
+++ b/src/main/java/com/undefinedus/backend/domain/enums/DiscussionStatus.java
@@ -5,8 +5,7 @@ public enum DiscussionStatus {
     SCHEDULED("대기중"),        // 토론 시작 전 (대기)
     IN_PROGRESS("진행중"),    // 토론 진행 중 (ONGOING보다 더 일반적인 표현)
     ANALYZING("분석중"),      // AI 분석 중
-    COMPLETED("종료됨"),
-    BLOCKED("차단됨");    // 신고 누적으로 인한 차단 상태 추가
+    COMPLETED("종료됨");
 
     private final String description;
     

--- a/src/main/java/com/undefinedus/backend/domain/enums/ViewStatus.java
+++ b/src/main/java/com/undefinedus/backend/domain/enums/ViewStatus.java
@@ -1,0 +1,6 @@
+package com.undefinedus.backend.domain.enums;
+
+public enum ViewStatus {
+    ACTIVE , // 평상시
+    BLOCKED // 누적 3건으로 자동으로 임시 승인됨 (관리자 확인 필요), 또는 관리자 확인후 처리
+}

--- a/src/main/java/com/undefinedus/backend/dto/response/discussion/DiscussionDetailResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/discussion/DiscussionDetailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.undefinedus.backend.dto.response.discussion;
 
+import com.undefinedus.backend.domain.enums.ViewStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
@@ -48,5 +49,7 @@ public class DiscussionDetailResponseDTO {
     private Boolean isReport;   // 로그인 사용자가 볼때 신고 했었는지
     
     private String isAgree; // isAgree, disAgree, null
+    
+    private ViewStatus viewStatus;  // Blocked 되었는지에 대한 필드
 
 }

--- a/src/main/java/com/undefinedus/backend/dto/response/discussion/DiscussionListResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/discussion/DiscussionListResponseDTO.java
@@ -1,5 +1,6 @@
 package com.undefinedus.backend.dto.response.discussion;
 
+import com.undefinedus.backend.domain.enums.ViewStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
@@ -41,4 +42,6 @@ public class DiscussionListResponseDTO {
     private String cover; // discussion 에서 myBook에 있는 isbn13을 뽑아 cover 링크를 뽑아 저장
 
     private String status; // 게시물 상태
+    
+    private ViewStatus viewStatus; // Blocked 되었는지에 대한 필드
 }

--- a/src/main/java/com/undefinedus/backend/dto/response/discussionComment/DiscussionCommentResponseDTO.java
+++ b/src/main/java/com/undefinedus/backend/dto/response/discussionComment/DiscussionCommentResponseDTO.java
@@ -1,5 +1,6 @@
 package com.undefinedus.backend.dto.response.discussionComment;
 
+import com.undefinedus.backend.domain.enums.DiscussionCommentStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
@@ -46,7 +47,7 @@ public class DiscussionCommentResponseDTO {
 
     private LocalDateTime createTime;
 
-    private String discussionCommentStatus;
+    private DiscussionCommentStatus viewStatus;
     
     private Boolean isReport;
 }

--- a/src/main/java/com/undefinedus/backend/scheduler/JobRestorer.java
+++ b/src/main/java/com/undefinedus/backend/scheduler/JobRestorer.java
@@ -2,6 +2,7 @@ package com.undefinedus.backend.scheduler;
 
 import com.undefinedus.backend.domain.entity.Discussion;
 import com.undefinedus.backend.domain.enums.DiscussionStatus;
+import com.undefinedus.backend.domain.enums.ViewStatus;
 import com.undefinedus.backend.repository.DiscussionRepository;
 import com.undefinedus.backend.scheduler.config.QuartzConfig;
 import com.undefinedus.backend.scheduler.entity.QuartzTrigger;
@@ -43,7 +44,7 @@ public class JobRestorer {
         for (Discussion discussion : discussionList) {
             if (discussion.getDeletedAt() == null &&
                 discussion.getStatus() != DiscussionStatus.COMPLETED &&
-                discussion.getStatus() != DiscussionStatus.BLOCKED) {
+                discussion.getViewStatus() != ViewStatus.BLOCKED) {
 
                 List<DiscussionStatus> statusList = getStatusListForProcessing(
                     discussion.getStatus());

--- a/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
@@ -278,7 +278,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
                 .dislike(dislikeCount)
                 .isSelected(false)
                 .createTime(createdDate)
-                .discussionCommentStatus(String.valueOf(discussionCommentStatus))
+                .viewStatus(discussionCommentStatus)
                 .isReport(isReport)  // 신고 여부 추가
                 .build();
 
@@ -489,7 +489,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
                 .dislike(dislikeCount)
                 .isSelected(true)
                 .createTime(createdDate)
-                .discussionCommentStatus(String.valueOf(discussionCommentStatus))
+                .viewStatus(discussionCommentStatus)
                 .build();
 
             responseDTOList.add(dto);

--- a/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionServiceImpl.java
@@ -165,6 +165,7 @@ public class DiscussionServiceImpl implements DiscussionService {
                 .status(String.valueOf(discussion.getStatus()))
                 .agreePercent(discussion.getAgreePercent())
                 .disagreePercent(discussion.getDisagreePercent())
+                .viewStatus(discussion.getViewStatus())
                 .build();
 
             responseDTOList.add(dto);
@@ -249,6 +250,7 @@ public class DiscussionServiceImpl implements DiscussionService {
             .disagreePercent(discussion.getDisagreePercent())
             .isReport(isReport)
             .isAgree(isAgree)
+            .viewStatus(discussion.getViewStatus())
             .build();
 
         return discussionDetailResponseDTO;

--- a/src/main/java/com/undefinedus/backend/service/ReportServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/ReportServiceImpl.java
@@ -8,6 +8,7 @@ import com.undefinedus.backend.domain.enums.DiscussionCommentStatus;
 import com.undefinedus.backend.domain.enums.DiscussionStatus;
 import com.undefinedus.backend.domain.enums.ReportStatus;
 import com.undefinedus.backend.domain.enums.ReportTargetType;
+import com.undefinedus.backend.domain.enums.ViewStatus;
 import com.undefinedus.backend.dto.request.ScrollRequestDTO;
 import com.undefinedus.backend.dto.request.report.ReportRequestDTO;
 import com.undefinedus.backend.dto.response.ScrollResponseDTO;
@@ -84,7 +85,7 @@ public class ReportServiceImpl implements ReportService {
                 reportRepository.saveAll(discussionReports);  // 변경된 신고들을 저장
 
                 // 상태 변경 후 토론 상태를 BLOCKED로 변경
-                discussion.changeStatus(DiscussionStatus.BLOCKED);
+                discussion.changeViewStatus(ViewStatus.BLOCKED);
                 discussionRepository.save(discussion);  // 변경된 토론 저장
                 entityManager.flush();
             }
@@ -225,7 +226,7 @@ public class ReportServiceImpl implements ReportService {
         report.changeStatus(ReportStatus.ACCEPTED);
 
         Optional.ofNullable(report.getDiscussion())
-            .ifPresent(discussion -> discussion.changeStatus(DiscussionStatus.BLOCKED));
+            .ifPresent(discussion -> discussion.changeViewStatus(ViewStatus.BLOCKED));
 
         Optional.ofNullable(report.getComment())
             .ifPresent(

--- a/src/test/java/com/undefinedus/backend/repository/DiscussionRepositoryTest.java
+++ b/src/test/java/com/undefinedus/backend/repository/DiscussionRepositoryTest.java
@@ -23,15 +23,6 @@ class DiscussionRepositoryTest {
     }
 
     @Test
-    @DisplayName("status 값 COMPLETED, BLOCKED 뺴고 조회")
-    public void findAll() {
-        List<Discussion> allByStatusNotClosed =
-            discussionRepository.findAllByStatusNotClosed();
-
-        System.out.println(allByStatusNotClosed);
-    }
-
-    @Test
     @DisplayName("토론 게시물 아이디 및 참여 인원 조회")
     public void findByIdWithParticipants() {
 

--- a/src/test/java/com/undefinedus/backend/service/ReportServiceImplTest.java
+++ b/src/test/java/com/undefinedus/backend/service/ReportServiceImplTest.java
@@ -14,6 +14,7 @@ import com.undefinedus.backend.domain.enums.DiscussionCommentStatus;
 import com.undefinedus.backend.domain.enums.DiscussionStatus;
 import com.undefinedus.backend.domain.enums.ReportStatus;
 import com.undefinedus.backend.domain.enums.ReportTargetType;
+import com.undefinedus.backend.domain.enums.ViewStatus;
 import com.undefinedus.backend.domain.enums.VoteType;
 import com.undefinedus.backend.dto.request.ScrollRequestDTO;
 import com.undefinedus.backend.dto.request.report.ReportRequestDTO;
@@ -293,7 +294,7 @@ class ReportServiceImplTest {
 
         Discussion blockedDiscussion = discussionRepository.findById(discussion.getId())
             .orElseThrow();
-        assertThat(blockedDiscussion.getStatus()).isEqualTo(DiscussionStatus.BLOCKED);
+        assertThat(blockedDiscussion.getViewStatus()).isEqualTo(ViewStatus.BLOCKED);
     }
 
     @Test
@@ -526,7 +527,7 @@ class ReportServiceImplTest {
             .build();
 
         Report savedReport = reportRepository.save(report);
-        discussion.changeStatus(DiscussionStatus.BLOCKED);  // 토론 상태를 BLOCKED로 변경
+        discussion.changeViewStatus(ViewStatus.BLOCKED);  // 토론 상태를 BLOCKED로 변경
 
         entityManager.flush();
         entityManager.clear();
@@ -558,7 +559,7 @@ class ReportServiceImplTest {
             .build();
 
         Report savedReport = reportRepository.save(report);
-        discussion.changeStatus(DiscussionStatus.BLOCKED);  // 토론 상태를 BLOCKED로 변경
+        discussion.changeViewStatus(ViewStatus.BLOCKED);  // 토론 상태를 BLOCKED로 변경
 
         entityManager.flush();
         entityManager.clear();
@@ -673,7 +674,7 @@ class ReportServiceImplTest {
             .orElseThrow();
 
         assertThat(approvedReport.getStatus()).isEqualTo(ReportStatus.ACCEPTED);
-        assertThat(blockedDiscussion.getStatus()).isEqualTo(DiscussionStatus.BLOCKED);
+        assertThat(blockedDiscussion.getViewStatus()).isEqualTo(ViewStatus.BLOCKED);
     }
 
     @Test


### PR DESCRIPTION
- Discussion 엔티티 업데이트, private ViewStatus viewStatus 추가
- 리포트시 Blocked의 경우   Status가 아니라  ViewStatus가 변경되도록  변경
- ViewStatus enum 추가
- JobRestorer 변경
- 테스트 코드 업데이트