### PR TITLE
fix(discussionComment): 댓글 조회 시 isReport 출력 에러 수정

### DIFF
--- a/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
+++ b/src/main/java/com/undefinedus/backend/service/DiscussionCommentServiceImpl.java
@@ -182,6 +182,9 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
         long discussionCommentTotal = discussionCommentRepository.findByDiscussion(
             discussion).stream().count();
 
+        Member member = memberRepository.findById(loginMemberId)
+            .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다 : " + loginMemberId));
+
         boolean hasNext = false;
         if (discussionCommentList.size()
             > discussionCommentsScrollRequestDTO.getSize()) { // 11 > 10 이면 있다는 뜻
@@ -195,7 +198,7 @@ public class DiscussionCommentServiceImpl implements DiscussionCommentService {
         for (DiscussionComment discussionComment : discussionCommentList) {
 
             DiscussionCommentResponseDTO commentResponseDTO = getCommentDTO(discussionComment,
-                discussionComment.getMember());
+                member);
 
             responseDTOList.add(commentResponseDTO);
         }


### PR DESCRIPTION
- 댓글 조회 시 로그인한 회원이 그 댓글을 신고하면 그 댓글의 isReport가 true여야 하는데 하나만 true로 출력, 로그인한 회원이 신고한 댓글은 true가 나오도록 수정 완료